### PR TITLE
docs: add missing English navbar items

### DIFF
--- a/website/content/en/_meta.ts
+++ b/website/content/en/_meta.ts
@@ -11,4 +11,24 @@ export default {
     type: 'page',
     title: 'Developer Guide',
   },
+  design: {
+    type: 'page',
+    title: 'Design',
+  },
+  showcase: {
+    type: 'page',
+    title: 'Showcase',
+    theme: {
+      sidebar: false,
+      layout: 'full'
+    }
+  },
+  blog: {
+    type: 'page',
+    title: 'Blog',
+    theme: {
+      sidebar: false,
+      layout: 'full'
+    }
+  },
 };


### PR DESCRIPTION
## Summary\n- add missing English navbar entries for Design, Showcase, and Blog\n- align English top-level meta with localized content navigation\n\n## Testing\n- not run (metadata-only documentation change)