### PR TITLE
feat: 添加 llms.txt 并优化 robots.txt，提升 AI 搜索引擎可见度（SEO/GEO）

### DIFF
--- a/website/app/robots.ts
+++ b/website/app/robots.ts
@@ -22,7 +22,41 @@ export default function robots(): MetadataRoute.Robots {
         userAgent: "*",
         allow: "/",
       },
+      // Explicitly allow major AI crawlers for GEO visibility
+      {
+        userAgent: "GPTBot",
+        allow: "/",
+      },
+      {
+        userAgent: "ChatGPT-User",
+        allow: "/",
+      },
+      {
+        userAgent: "ClaudeBot",
+        allow: "/",
+      },
+      {
+        userAgent: "PerplexityBot",
+        allow: "/",
+      },
+      {
+        userAgent: "Google-Extended",
+        allow: "/",
+      },
+      {
+        userAgent: "Bytespider",
+        allow: "/",
+      },
+      {
+        userAgent: "Applebot-Extended",
+        allow: "/",
+      },
+      {
+        userAgent: "cohere-ai",
+        allow: "/",
+      },
     ],
     sitemap: `${siteUrl}/sitemap.xml`,
+    host: siteUrl,
   };
 }

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -1,0 +1,60 @@
+# Qwen Code
+
+> Qwen Code is an open-source AI coding agent by Alibaba. It integrates with VS Code, JetBrains, Zed, and GitHub Actions to help developers write, review, and refactor code using large language models.
+
+## Documentation
+
+- [Overview](https://qwenlm.github.io/qwen-code-docs/en/users/overview/): What Qwen Code is, core capabilities, and supported platforms
+- [Quick Start](https://qwenlm.github.io/qwen-code-docs/en/users/quickstart/): Installation and first-run guide
+- [Common Workflows](https://qwenlm.github.io/qwen-code-docs/en/users/common-workflow/): Everyday usage patterns and best practices
+
+## IDE Integration
+
+- [VS Code](https://qwenlm.github.io/qwen-code-docs/en/users/integration-vscode/): Setup and usage in Visual Studio Code
+- [JetBrains](https://qwenlm.github.io/qwen-code-docs/en/users/integration-jetbrains/): Setup and usage in IntelliJ, WebStorm, PyCharm, etc.
+- [Zed](https://qwenlm.github.io/qwen-code-docs/en/users/integration-zed/): Setup and usage in Zed editor
+- [GitHub Actions](https://qwenlm.github.io/qwen-code-docs/en/users/integration-github-action/): CI/CD automation with Qwen Code
+
+## Features
+
+- [MCP Servers](https://qwenlm.github.io/qwen-code-docs/en/users/features/mcp/): Model Context Protocol server integration
+- [Memory System](https://qwenlm.github.io/qwen-code-docs/en/users/features/memory/): Persistent memory across sessions
+- [Skills](https://qwenlm.github.io/qwen-code-docs/en/users/features/skills/): Custom skill definitions for specialized tasks
+- [Sub-Agents](https://qwenlm.github.io/qwen-code-docs/en/users/features/sub-agents/): Parallel task execution with forked agents
+- [Sandbox](https://qwenlm.github.io/qwen-code-docs/en/users/features/sandbox/): Isolated code execution environment
+- [Code Review](https://qwenlm.github.io/qwen-code-docs/en/users/features/code-review/): AI-assisted code review
+- [Headless Mode](https://qwenlm.github.io/qwen-code-docs/en/users/features/headless/): Run without UI for automation
+- [Scheduled Tasks](https://qwenlm.github.io/qwen-code-docs/en/users/features/scheduled-tasks/): Timer-based automated workflows
+- [Channels](https://qwenlm.github.io/qwen-code-docs/en/users/features/channels/overview/): DingTalk, Telegram, WeChat integrations
+- [Approval Mode](https://qwenlm.github.io/qwen-code-docs/en/users/features/approval-mode/): Human-in-the-loop confirmation
+- [Checkpointing](https://qwenlm.github.io/qwen-code-docs/en/users/features/checkpointing/): Git-based session checkpoints
+- [Commands](https://qwenlm.github.io/qwen-code-docs/en/users/features/commands/): Slash commands reference
+- [Token Caching](https://qwenlm.github.io/qwen-code-docs/en/users/features/token-caching/): Prompt caching for cost reduction
+
+## Configuration
+
+- [Model Providers](https://qwenlm.github.io/qwen-code-docs/en/users/configuration/model-providers/): Configure LLM providers and API keys
+- [Authentication](https://qwenlm.github.io/qwen-code-docs/en/users/configuration/auth/): Auth setup and token management
+- [Settings](https://qwenlm.github.io/qwen-code-docs/en/users/configuration/settings/): All configuration options
+- [Themes](https://qwenlm.github.io/qwen-code-docs/en/users/configuration/themes/): UI theme customization
+- [QwenIgnore](https://qwenlm.github.io/qwen-code-docs/en/users/configuration/qwen-ignore/): File exclusion rules
+
+## Developer Guide
+
+- [Architecture](https://qwenlm.github.io/qwen-code-docs/en/developers/architecture/): System architecture and design
+- [Contributing](https://qwenlm.github.io/qwen-code-docs/en/developers/contributing/): How to contribute
+- [Roadmap](https://qwenlm.github.io/qwen-code-docs/en/developers/roadmap/): Development roadmap
+- [Tools Reference](https://qwenlm.github.io/qwen-code-docs/en/developers/tools/introduction/): Built-in tool system documentation
+- [Extensions](https://qwenlm.github.io/qwen-code-docs/en/developers/extensions/extension/): Extension development guide
+- [SDK - Python](https://qwenlm.github.io/qwen-code-docs/en/developers/sdk-python/): Python SDK
+- [SDK - TypeScript](https://qwenlm.github.io/qwen-code-docs/en/developers/sdk-typescript/): TypeScript SDK
+- [SDK - Java](https://qwenlm.github.io/qwen-code-docs/en/developers/sdk-java/): Java SDK
+
+## Blog
+
+- [Blog Index](https://qwenlm.github.io/qwen-code-docs/en/blog/): Release announcements, tutorials, and weekly updates
+
+## Support
+
+- [Troubleshooting](https://qwenlm.github.io/qwen-code-docs/en/users/support/troubleshooting/): Common issues and solutions
+- [Terms & Privacy](https://qwenlm.github.io/qwen-code-docs/en/users/support/tos-privacy/): Legal information


### PR DESCRIPTION
## 改动说明

### 做了什么

1. **新增 `website/public/llms.txt`**
   - 为 AI 搜索引擎提供结构化的站点内容目录
   - 按 Overview、IDE Integration、Features、Configuration、Developer Guide、Blog、Support 分区组织所有文档链接
   - 每个条目包含标题、URL 和简短描述

2. **优化 `website/app/robots.ts`**
   - 显式允许 8 个主流 AI 爬虫访问站点：GPTBot、ChatGPT-User、ClaudeBot、PerplexityBot、Google-Extended、Bytespider、Applebot-Extended、cohere-ai
   - 添加 `host` 字段确认规范域名

### 为什么这么做

**背景：SEO → GEO 的趋势变化**

越来越多用户通过 AI 搜索（ChatGPT、Perplexity、Google AI Overview、通义搜索等）获取信息，而不是传统搜索引擎。GEO（Generative Engine Optimization，生成式引擎优化）是让网站内容在 AI 搜索中被引用为信源的优化方式。

**`llms.txt` 的作用**

- 这是 [llmstxt.org](https://llmstxt.org/) 提出的标准，类似 `robots.txt` 之于搜索引擎，`llms.txt` 是给 AI 模型看的站点目录
- 当 AI 需要回答关于 Qwen Code 的问题时，它会通过这个文件快速了解站点有哪些内容，然后抓取相关页面作为回答信源
- 没有这个文件，AI 只能盲目爬取，可能漏掉重要文档页面

**显式允许 AI 爬虫的原因**

- 部分 AI 爬虫（如 GPTBot）在 `robots.txt` 中未被明确提及时会降低抓取优先级
- 作为开源项目文档站，我们**希望**被 AI 引用——用户问"Qwen Code 怎么用 MCP？"时，应该引用官方文档而非过时的第三方博客
- 覆盖的爬虫：OpenAI（GPTBot/ChatGPT-User）、Anthropic（ClaudeBot）、Perplexity、Google AI（Google-Extended）、字节跳动（Bytespider）、Apple Intelligence（Applebot-Extended）、Cohere

### 预期效果

```
用户问 AI："Qwen Code 怎么配置 MCP？"
  → AI 爬虫发现 llms.txt → 定位到 MCP 文档条目
  → 抓取页面内容 → 生成回答时引用官方文档
  → 用户看到来源: qwenlm.github.io/qwen-code-docs
```