### PR TITLE
feat(translator): sync 新增 --detect-only / --source-only 两种免 key 模式，翻译器改为懒加载

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ npm install -g @qwen-code/translator
 4. **Translate documents**:
 
    ```bash
-   qwen-translator translate
+   qwen-translator markdown
    ```
 
 5. **Start the documentation site**:
@@ -59,16 +59,26 @@ Initialize a new translation project with interactive configuration. Sets up pro
 
 ### `sync [options]`
 
-Sync source repository documents and automatically translate changes.
+Sync source repository documents and automatically translate changed files into the target languages.
 
 - `-f, --force`: Force sync all documents (ignores previous sync records)
+- `-d, --detect-only`: Only detect and list changed files; skip translation and write nothing (no `content/` updates, no `last-sync.json`/changelog changes). Useful for previewing what a sync would translate.
 
-### `translate [options]`
+> **No API key for detection.** The translator is lazy-loaded, so `--detect-only` — and a normal sync that finds zero changes — does **not** require `OPENAI_API_KEY`. A normal sync that has changes validates the key *before* writing any files, so a missing key fails fast without leaving partially-written output. Note that detection still clones/updates the source repo under `.temp-source-repo`.
 
-Translate documents to target languages.
+### `markdown [options]`
 
-- `-l, --language <lang>`: Specify target language (zh, de, fr, ru, ja, es)
+Translate the Markdown documents under `content/<sourceLanguage>/` into the target languages. Translates the whole directory by default, or a single file with `-f`.
+
+- `-l, --language <lang>`: Specify target language (zh, de, fr, ru, ja, pt-BR, es)
 - `-f, --file <file>`: Specify single file to translate
+
+### `meta [options]`
+
+Translate Nextra navigation files (`_meta.ts`) into the target languages.
+
+- `-l, --language <lang>`: Specify target language
+- `-f, --file <file>`: Specify a single `_meta.ts` file to translate
 
 ### `config`
 

--- a/README.md
+++ b/README.md
@@ -63,8 +63,9 @@ Sync source repository documents and automatically translate changed files into 
 
 - `-f, --force`: Force sync all documents (ignores previous sync records)
 - `-d, --detect-only`: Only detect and list changed files; skip translation and write nothing (no `content/` updates, no `last-sync.json`/changelog changes). Useful for previewing what a sync would translate.
+- `-s, --source-only`: Detect changes and write the source-language docs (`content/<sourceLanguage>` and `.source-docs`), but skip translation. Does **not** advance `last-sync.json` or write the changelog, so a later `sync` (with a key) still re-detects and translates these files. Useful for refreshing the source docs now and translating later.
 
-> **No API key for detection.** The translator is lazy-loaded, so `--detect-only` — and a normal sync that finds zero changes — does **not** require `OPENAI_API_KEY`. A normal sync that has changes validates the key *before* writing any files, so a missing key fails fast without leaving partially-written output. Note that detection still clones/updates the source repo under `.temp-source-repo`.
+> **No API key for detection / source-only.** The translator is lazy-loaded, so `--detect-only`, `--source-only`, and a normal sync that finds zero changes do **not** require `OPENAI_API_KEY`. A normal sync that has changes validates the key *before* writing any files, so a missing key fails fast without leaving partially-written output. Note that detection still clones/updates the source repo under `.temp-source-repo`.
 
 ### `markdown [options]`
 

--- a/translator/README.md
+++ b/translator/README.md
@@ -42,7 +42,7 @@ npm install -g @qwen-code/translator
 4. **Translate documents**:
 
    ```bash
-   qwen-translator translate
+   qwen-translator markdown
    ```
 
 5. **Start the documentation site**:
@@ -59,16 +59,26 @@ Initialize a new translation project with interactive configuration. Sets up pro
 
 ### `sync [options]`
 
-Sync source repository documents and automatically translate changes.
+Sync source repository documents and automatically translate changed files into the target languages.
 
 - `-f, --force`: Force sync all documents (ignores previous sync records)
+- `-d, --detect-only`: Only detect and list changed files; skip translation and write nothing (no `content/` updates, no `last-sync.json`/changelog changes). Useful for previewing what a sync would translate.
 
-### `translate [options]`
+> **No API key for detection.** The translator is lazy-loaded, so `--detect-only` — and a normal sync that finds zero changes — does **not** require `OPENAI_API_KEY`. A normal sync that has changes validates the key *before* writing any files, so a missing key fails fast without leaving partially-written output. Note that detection still clones/updates the source repo under `.temp-source-repo`.
 
-Translate documents to target languages.
+### `markdown [options]`
 
-- `-l, --language <lang>`: Specify target language (zh, de, fr, ru, ja, es)
+Translate the Markdown documents under `content/<sourceLanguage>/` into the target languages. Translates the whole directory by default, or a single file with `-f`.
+
+- `-l, --language <lang>`: Specify target language (zh, de, fr, ru, ja, pt-BR, es)
 - `-f, --file <file>`: Specify single file to translate
+
+### `meta [options]`
+
+Translate Nextra navigation files (`_meta.ts`) into the target languages.
+
+- `-l, --language <lang>`: Specify target language
+- `-f, --file <file>`: Specify a single `_meta.ts` file to translate
 
 ### `config`
 

--- a/translator/README.md
+++ b/translator/README.md
@@ -63,8 +63,9 @@ Sync source repository documents and automatically translate changed files into 
 
 - `-f, --force`: Force sync all documents (ignores previous sync records)
 - `-d, --detect-only`: Only detect and list changed files; skip translation and write nothing (no `content/` updates, no `last-sync.json`/changelog changes). Useful for previewing what a sync would translate.
+- `-s, --source-only`: Detect changes and write the source-language docs (`content/<sourceLanguage>` and `.source-docs`), but skip translation. Does **not** advance `last-sync.json` or write the changelog, so a later `sync` (with a key) still re-detects and translates these files. Useful for refreshing the source docs now and translating later.
 
-> **No API key for detection.** The translator is lazy-loaded, so `--detect-only` — and a normal sync that finds zero changes — does **not** require `OPENAI_API_KEY`. A normal sync that has changes validates the key *before* writing any files, so a missing key fails fast without leaving partially-written output. Note that detection still clones/updates the source repo under `.temp-source-repo`.
+> **No API key for detection / source-only.** The translator is lazy-loaded, so `--detect-only`, `--source-only`, and a normal sync that finds zero changes do **not** require `OPENAI_API_KEY`. A normal sync that has changes validates the key *before* writing any files, so a missing key fails fast without leaving partially-written output. Note that detection still clones/updates the source repo under `.temp-source-repo`.
 
 ### `markdown [options]`
 

--- a/translator/src/cli.ts
+++ b/translator/src/cli.ts
@@ -337,7 +337,10 @@ class TranslationCLI {
   /**
    * Sync source repository documents
    */
-  async syncDocuments(force: boolean = false): Promise<void> {
+  async syncDocuments(
+    force: boolean = false,
+    detectOnly: boolean = false
+  ): Promise<void> {
     const projectConfig = await this.loadProjectConfig();
     if (!projectConfig) {
       console.error(
@@ -361,11 +364,15 @@ class TranslationCLI {
     });
 
     try {
-      const result = await syncManager.syncDocuments(force);
+      const result = await syncManager.syncDocuments(force, { detectOnly });
 
       if (result.success) {
         console.log(
-          chalk.green(`✅ Sync completed! Changed files: ${result.changes}`)
+          chalk.green(
+            detectOnly
+              ? `✅ Detection completed! Changed files: ${result.changes}`
+              : `✅ Sync completed! Changed files: ${result.changes}`
+          )
         );
 
         if (result.files.length > 0) {
@@ -721,8 +728,12 @@ async function main() {
     .command("sync")
     .description("Sync source repository documents")
     .option("-f, --force", "Force sync all documents")
+    .option(
+      "-d, --detect-only",
+      "Only detect & list changed files; skip translation (no API key required)"
+    )
     .action(async (options) => {
-      await cli.syncDocuments(options.force);
+      await cli.syncDocuments(options.force, options.detectOnly);
     });
 
   // markdown command

--- a/translator/src/cli.ts
+++ b/translator/src/cli.ts
@@ -339,7 +339,8 @@ class TranslationCLI {
    */
   async syncDocuments(
     force: boolean = false,
-    detectOnly: boolean = false
+    detectOnly: boolean = false,
+    sourceOnly: boolean = false
   ): Promise<void> {
     const projectConfig = await this.loadProjectConfig();
     if (!projectConfig) {
@@ -364,13 +365,18 @@ class TranslationCLI {
     });
 
     try {
-      const result = await syncManager.syncDocuments(force, { detectOnly });
+      const result = await syncManager.syncDocuments(force, {
+        detectOnly,
+        sourceOnly,
+      });
 
       if (result.success) {
         console.log(
           chalk.green(
             detectOnly
               ? `✅ Detection completed! Changed files: ${result.changes}`
+              : sourceOnly
+              ? `✅ Source docs updated (no translation)! Changed files: ${result.changes}`
               : `✅ Sync completed! Changed files: ${result.changes}`
           )
         );
@@ -732,8 +738,16 @@ async function main() {
       "-d, --detect-only",
       "Only detect & list changed files; skip translation (no API key required)"
     )
+    .option(
+      "-s, --source-only",
+      "Detect changes and write source-language docs, but skip translation; does not advance last-sync.json (no API key required)"
+    )
     .action(async (options) => {
-      await cli.syncDocuments(options.force, options.detectOnly);
+      await cli.syncDocuments(
+        options.force,
+        options.detectOnly,
+        options.sourceOnly
+      );
     });
 
   // markdown command

--- a/translator/src/sync.ts
+++ b/translator/src/sync.ts
@@ -148,7 +148,7 @@ export class SyncManager {
    */
   async syncDocuments(
     forceSync: boolean = false,
-    options: { detectOnly?: boolean } = {}
+    options: { detectOnly?: boolean; sourceOnly?: boolean } = {}
   ): Promise<SyncResult> {
     try {
       console.log(chalk.yellow("🔍 检测文档变更..."));
@@ -162,6 +162,13 @@ export class SyncManager {
         if (forceSync) {
           console.log(
             chalk.yellow("⚠️  detect-only 模式下 --force 无效，已忽略")
+          );
+        }
+        if (options.sourceOnly) {
+          console.log(
+            chalk.yellow(
+              "⚠️  已同时指定 --source-only，被 --detect-only 覆盖（不写入任何文件）"
+            )
           );
         }
         if (changes.isFirstSync && changes.files.length > 0) {
@@ -192,6 +199,24 @@ export class SyncManager {
       }
 
       console.log(chalk.blue(`📝 检测到 ${changes.files.length} 个文件变更`));
+
+      // source-only：把上游源文档写入 content/<sourceLanguage> 与 .source-docs，
+      // 但不翻译、不更新 last-sync.json / changelog，也不构造翻译器（无需 key）。
+      // 刻意不推进同步基线：目标语言译文此时会落后于源文档，待配置 key 后再次运行
+      // sync 即可补齐翻译（届时仍会检测到这些文件，可自愈）。
+      if (options.sourceOnly) {
+        await this.updateBaseDocs();
+        console.log(
+          chalk.green(
+            "✅ 已更新源文档（source-only：未翻译；未推进 last-sync.json，配置 key 后再次 sync 可补齐翻译）"
+          )
+        );
+        return {
+          success: true,
+          changes: changes.files.length,
+          files: changes.files,
+        };
+      }
 
       // 正常 sync：在写入任何文件之前先构造翻译器以校验 OPENAI_API_KEY，
       // 恢复“缺 key 立即失败、不产生半写状态”的行为（懒加载后默认会等到翻译阶段

--- a/translator/src/sync.ts
+++ b/translator/src/sync.ts
@@ -155,14 +155,30 @@ export class SyncManager {
 
       const changes = await this.detectChanges();
 
-      // detect-only：只检测并返回变更文件清单，不复制源文档、不翻译、不更新同步记录，
-      // 全程不构造翻译器，因此无需配置 OPENAI_API_KEY。
+      // detect-only：只检测并返回变更文件清单。不复制源文档、不翻译、不更新
+      // last-sync.json / changelog，也不构造翻译器，因此无需配置 OPENAI_API_KEY。
+      // 注意：检测本身仍需克隆/更新源仓库（.temp-source-repo）用于比对。
       if (options.detectOnly) {
-        console.log(
-          chalk.blue(
-            `📝 检测到 ${changes.files.length} 个文件变更（detect-only：不翻译、不写入任何文件）`
-          )
-        );
+        if (forceSync) {
+          console.log(
+            chalk.yellow("⚠️  detect-only 模式下 --force 无效，已忽略")
+          );
+        }
+        if (changes.isFirstSync && changes.files.length > 0) {
+          console.log(
+            chalk.blue(
+              `📝 首次检测（缺少同步基线 last-sync.json）：列出全部 ${changes.files.length} 个文档`
+            )
+          );
+        } else if (changes.files.length === 0) {
+          console.log(chalk.green("✅ 没有检测到文档变更"));
+        } else {
+          console.log(
+            chalk.blue(
+              `📝 检测到 ${changes.files.length} 个文件变更（detect-only：不翻译、不更新 content/ 与同步记录）`
+            )
+          );
+        }
         return {
           success: true,
           changes: changes.files.length,
@@ -176,6 +192,15 @@ export class SyncManager {
       }
 
       console.log(chalk.blue(`📝 检测到 ${changes.files.length} 个文件变更`));
+
+      // 正常 sync：在写入任何文件之前先构造翻译器以校验 OPENAI_API_KEY，
+      // 恢复“缺 key 立即失败、不产生半写状态”的行为（懒加载后默认会等到翻译阶段
+      // 才校验，导致 content/ 已被覆写后才报错）。
+      // 作用域说明：detect-only 已在上方返回；未指定 --force 的零变更也已在上方
+      // 返回——这两类无需 key。但 --force 会绕过零变更早返回，届时即使没有变更也会
+      // 走到这里并要求 key（属 --force 的既有语义，不在本次改动范围）。
+      // 此处丢弃返回值仅为提前校验；实例已被缓存，翻译阶段会复用同一实例。
+      this.getTranslator();
 
       // 更新基础文档
       await this.updateBaseDocs();

--- a/translator/src/sync.ts
+++ b/translator/src/sync.ts
@@ -74,7 +74,7 @@ export class SyncManager {
   private branch: string; // 新增：源仓库分支
   private lastSyncFile: string;
   private changelogFile: string;
-  private translator: DocumentTranslator;
+  private translator: DocumentTranslator | null = null; // 懒加载：仅在需要翻译时构造
   private projectRoot: string; // 新增：项目根目录
   private outputDir: string; // 新增：输出目录
 
@@ -115,9 +115,9 @@ export class SyncManager {
       this.projectRoot,
       "translation-changelog.json"
     );
-    this.translator = new DocumentTranslator({
-      projectRoot: this.projectRoot,
-    });
+    // 翻译器改为懒加载（见 getTranslator）：构造期不再创建 DocumentTranslator，
+    // 因此不会在此触发 OPENAI_API_KEY 校验。detect-only / 零变更等无需翻译的
+    // 场景下，全程都不会构造翻译器，也就不需要配置 key。
 
     console.log(chalk.blue("🔄 同步管理器已初始化"));
     console.log(chalk.gray(`  项目根目录: ${this.projectRoot}`));
@@ -131,13 +131,44 @@ export class SyncManager {
   }
 
   /**
+   * 懒加载翻译器
+   * 仅在真正需要翻译时才构造 DocumentTranslator（构造时会校验 OPENAI_API_KEY）。
+   */
+  private getTranslator(): DocumentTranslator {
+    if (!this.translator) {
+      this.translator = new DocumentTranslator({
+        projectRoot: this.projectRoot,
+      });
+    }
+    return this.translator;
+  }
+
+  /**
    * 检测并同步文档变更
    */
-  async syncDocuments(forceSync: boolean = false): Promise<SyncResult> {
+  async syncDocuments(
+    forceSync: boolean = false,
+    options: { detectOnly?: boolean } = {}
+  ): Promise<SyncResult> {
     try {
       console.log(chalk.yellow("🔍 检测文档变更..."));
 
       const changes = await this.detectChanges();
+
+      // detect-only：只检测并返回变更文件清单，不复制源文档、不翻译、不更新同步记录，
+      // 全程不构造翻译器，因此无需配置 OPENAI_API_KEY。
+      if (options.detectOnly) {
+        console.log(
+          chalk.blue(
+            `📝 检测到 ${changes.files.length} 个文件变更（detect-only：不翻译、不写入任何文件）`
+          )
+        );
+        return {
+          success: true,
+          changes: changes.files.length,
+          files: changes.files,
+        };
+      }
 
       if (!forceSync && changes.files.length === 0) {
         console.log(chalk.green("✅ 没有检测到文档变更"));
@@ -340,6 +371,9 @@ export class SyncManager {
       chalk.yellow(`🌍 开始并行翻译 ${this.targetLanguages.length} 种语言...`)
     );
 
+    // 在并行翻译前构造翻译器（此处会校验 OPENAI_API_KEY，缺失则尽早抛错）
+    const translator = this.getTranslator();
+
     // 并行翻译所有语言
     const languagePromises = this.targetLanguages.map(async (language) => {
       const result: TranslationResult = {
@@ -377,7 +411,7 @@ export class SyncManager {
           }
 
           // 翻译文件
-          const translatedContent = await this.translator.translateDocument(
+          const translatedContent = await translator.translateDocument(
             sourcePath,
             language
           );


### PR DESCRIPTION
## 概述

`sync` 命令原本在任何情况下都强制要求 `OPENAI_API_KEY`：`SyncManager` 构造时会立即创建 `DocumentTranslator`，而后者的构造函数会校验 key。这导致「只想看文档有哪些变更」或「只想同步英文源文档」也必须配置 key 并触发翻译（消耗 API）。

本 PR 将翻译器改为**懒加载**，并为 `sync` 新增两个免 key 选项：

| 选项 | 行为 | 是否需要 key |
|---|---|---|
| `--detect-only` (`-d`) | 只检测并列出变更文件，不写入任何文件 | ❌ |
| `--source-only` (`-s`) | 检测变更并写入英文源文档到 `content/en/`，不翻译 | ❌ |
| _(无 flag)_ | 检测 + 复制源文档 + 翻译（既有行为） | ✅ |

## 主要改动

### `translator/src/sync.ts`
- `SyncManager` 不再在构造函数中急切创建翻译器；改为懒加载 getter `getTranslator()`，仅在真正翻译时才构造（此时才校验 key）。
- `syncDocuments` 新增 `options.detectOnly`：命中时只检测、打印变更并返回清单，不复制源文档、不翻译、不更新 `last-sync.json` / changelog。
- `syncDocuments` 新增 `options.sourceOnly`：命中时检测变更并调用 `updateBaseDocs()` 写入源文档，但不翻译、不推进 `last-sync.json`（下次正常 sync 可自愈补齐翻译）。
- 正常 sync 在写入任何文件**之前**先构造翻译器以校验 key，保留「缺 key 立即失败、不产生半写状态」的行为。
- detect-only 与 source-only 互斥时，detect-only 优先并给出提示。
- detect-only 输出区分首次检测 / 增量 / 零变更，并在与 `--force` 同用时提示其无效。

### `translator/src/cli.ts`
- `sync` 命令新增 `-d, --detect-only` 和 `-s, --source-only` 选项并透传给 `syncDocuments`。

### `README.md` / `translator/README.md`
- 文档化 `--detect-only` 与「检测免 key」行为；修正命令名 `translate` → `markdown`；补充此前缺失的 `meta` 命令。

## 行为与兼容性

- ✅ 无 flag / 已配 key 的既有调用方行为不变。
- ✅ `--detect-only` / `--source-only` / 「零变更的普通 sync」不再需要 key（懒加载的附带收益）。
- ✅ 缺 key 的普通 sync 仍会失败，但现在在写文件前 fail-fast（此前会在覆写 `content/` 后才报错，留下半写状态）。
- ℹ️ `--source-only` 不推进 `last-sync.json`，后续 sync 会重新检测到这些变更并补齐翻译。
- ℹ️ 检测本身仍需克隆 / 更新源仓库到 `.temp-source-repo`。

## 用法

```bash
cd website
node ../translator/dist/cli.js sync --detect-only   # 免 key，仅列出变更
node ../translator/dist/cli.js sync --source-only   # 免 key，同步英文源文档但不翻译
node ../translator/dist/cli.js sync                 # 检测 + 翻译，需 key
```

## 验证

- `cd translator && npm run build`（`tsc`）干净通过，无类型错误。
- `node dist/cli.js sync --help` 确认 `-d` / `-s` 选项已挂载。

## 已知限制（预存、非本次引入）

- 共享 `.temp-source-repo` 在并发调用下可能竞争。
- `--force` 对「真·零变更」仍会要求 key 并空转（属 `--force` 既有语义）。