### PR TITLE
fix(ci): build docs on Node 22 with a larger heap

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 22
           run_install: false
 
       - name: Install dependencies
@@ -32,9 +32,11 @@ jobs:
         run: npm run build
         working-directory: ./website
         env:
-          # Docs set grew large (multi-locale + synced source docs); raise the
-          # V8 heap so `next build` doesn't OOM at the default ~4GB old-space cap.
-          NODE_OPTIONS: --max-old-space-size=8192
+          # Full multi-locale docs set is memory-heavy to statically export.
+          # Node 22 (above) is far more memory-efficient than the previous
+          # Node 18 (local full build peaks ~5.8GB); 12GB heap on the 16GB
+          # runner leaves comfortable headroom for future growth.
+          NODE_OPTIONS: --max-old-space-size=12288
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
## Problem

The **Build and Deploy** workflow on `main` started failing with `JavaScript heap out of memory` after the full multi-locale docs set landed (#129) — every locale now carries all 184 docs (~1.5k static pages total). The build hit the 8GB old-space cap during static export on **Node 18**.

## Root cause

It is not simply "too many pages." A full local build (all locales, 1504 pages) on **Node 22** peaks at only **~5.8GB RSS** and completes cleanly. The CI was running **Node 18** (EOL since April 2025), which is far less memory-efficient and blew past the 8GB cap.

## Fix

- **Node 18 → 22** in CI — matches the locally-validated environment; Node 22 is significantly more memory-efficient.
- **`max-old-space-size` 8192 → 12288** for comfortable headroom on the 16GB runner.

## Verification

Local full build on Node 22 with these settings: `✓ Compiled successfully`, `✓ Generating static pages (1504/1504)`, peak RSS ~5.8GB — well under the 12GB cap.

## Follow-up (separate)

The non-navigable internal docs (`e2e-tests/`, `plans/`, `superpowers/`, `verification/`) are currently translated and built for every locale despite never appearing in the site nav. Excluding them would cut translation cost and build memory further — tracked separately; not required to fix CI.