### PR TITLE
fix(translator): retry transient API disconnects

### DIFF
--- a/.github/workflows/daily-translate.yml
+++ b/.github/workflows/daily-translate.yml
@@ -37,10 +37,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
-      - name: Checkout main
+      - name: Checkout workflow ref
         uses: actions/checkout@v4
         with:
-          ref: main
+          ref: ${{ github.ref }}
           fetch-depth: 0
 
       - name: Install Node.js
@@ -89,7 +89,11 @@ jobs:
         run: |
           if [ -n "$(git status --porcelain website/content website/last-sync.json website/translation-changelog.json)" ]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
-            echo "Changes detected — will build, commit and deploy."
+            if [ "$GITHUB_REF_NAME" = "main" ]; then
+              echo "Changes detected — will build, commit and deploy."
+            else
+              echo "Changes detected — will build only because this run is on $GITHUB_REF_NAME."
+            fi
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"
             echo "No upstream doc changes today — nothing to do."
@@ -103,7 +107,7 @@ jobs:
         run: npm run build
 
       - name: Commit translations to main
-        if: steps.detect.outputs.changed == 'true'
+        if: steps.detect.outputs.changed == 'true' && github.ref_name == 'main'
         run: |
           git config user.name "qwen-docs-bot"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -112,7 +116,7 @@ jobs:
           git push origin HEAD:main
 
       - name: Deploy to GitHub Pages
-        if: steps.detect.outputs.changed == 'true'
+        if: steps.detect.outputs.changed == 'true' && github.ref_name == 'main'
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/daily-translate.yml
+++ b/.github/workflows/daily-translate.yml
@@ -56,41 +56,6 @@ jobs:
         working-directory: ./website
         run: npm ci --no-audit --no-fund
 
-      - name: Probe translation endpoint from GitHub runner
-        env:
-          OPENAI_API_KEY: ${{ secrets.TRANSLATE_API_KEY }}
-          OPENAI_BASE_URL: https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1
-          QWEN_MODEL: deepseek-v4-flash
-        run: |
-          set -euo pipefail
-
-          echo "== unauthenticated /models probe =="
-          curl -sS \
-            --connect-timeout 10 \
-            --max-time 20 \
-            -o /tmp/models.json \
-            -w "http_code=%{http_code}\nremote_ip=%{remote_ip}\ntime_connect=%{time_connect}\ntime_appconnect=%{time_appconnect}\ntime_total=%{time_total}\n" \
-            "$OPENAI_BASE_URL/models"
-
-          echo "== authenticated /chat/completions probe =="
-          chat_payload=$(
-            jq -nc --arg model "$QWEN_MODEL" \
-              '{model: $model, messages: [{role: "user", content: "ping"}], max_tokens: 1}'
-          )
-          curl -sS \
-            --connect-timeout 10 \
-            --max-time 40 \
-            -H "Authorization: Bearer $OPENAI_API_KEY" \
-            -H "Content-Type: application/json" \
-            -d "$chat_payload" \
-            -o /tmp/chat.json \
-            -w "http_code=%{http_code}\nremote_ip=%{remote_ip}\ntime_connect=%{time_connect}\ntime_appconnect=%{time_appconnect}\ntime_total=%{time_total}\n" \
-            "$OPENAI_BASE_URL/chat/completions"
-
-          echo "== chat response preview =="
-          head -c 1000 /tmp/chat.json
-          echo
-
       - name: Run incremental translation sync
         working-directory: ./website
         env:

--- a/.github/workflows/daily-translate.yml
+++ b/.github/workflows/daily-translate.yml
@@ -67,6 +67,11 @@ jobs:
           # deepseek-v4-flash output cap is large (384K); 32K already exceeds any
           # single doc's needs, and oversized files still auto-chunk under it.
           QWEN_MAX_TOKENS: "32768"
+          # The MaaS compatible endpoint can close long responses when all
+          # target languages run at once. Keep CI conservative and let API
+          # retries handle transient disconnects.
+          QWEN_TRANSLATION_CONCURRENCY: "1"
+          QWEN_API_MAX_RETRIES: "4"
         run: |
           set -o pipefail
           node ../translator/bin/qwen-translator sync 2>&1 | tee /tmp/sync.log

--- a/.github/workflows/daily-translate.yml
+++ b/.github/workflows/daily-translate.yml
@@ -64,9 +64,8 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.TRANSLATE_API_KEY }}
           OPENAI_BASE_URL: https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1
           QWEN_MODEL: deepseek-v4-flash
-          # deepseek-v4-flash output cap is large (384K); 32K already exceeds any
-          # single doc's needs, and oversized files still auto-chunk under it.
-          QWEN_MAX_TOKENS: "32768"
+          # Keep each response moderate; larger docs auto-chunk from this cap.
+          QWEN_MAX_TOKENS: "8192"
           # The MaaS compatible endpoint can close long responses when all
           # target languages run at once. Keep CI conservative and let API
           # retries handle transient disconnects.

--- a/.github/workflows/daily-translate.yml
+++ b/.github/workflows/daily-translate.yml
@@ -58,6 +58,41 @@ jobs:
         working-directory: ./website
         run: npm ci --no-audit --no-fund
 
+      - name: Probe translation endpoint from GitHub runner
+        env:
+          OPENAI_API_KEY: ${{ secrets.TRANSLATE_API_KEY }}
+          OPENAI_BASE_URL: https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1
+          QWEN_MODEL: deepseek-v4-flash
+        run: |
+          set -euo pipefail
+
+          echo "== unauthenticated /models probe =="
+          curl -sS \
+            --connect-timeout 10 \
+            --max-time 20 \
+            -o /tmp/models.json \
+            -w "http_code=%{http_code}\nremote_ip=%{remote_ip}\ntime_connect=%{time_connect}\ntime_appconnect=%{time_appconnect}\ntime_total=%{time_total}\n" \
+            "$OPENAI_BASE_URL/models"
+
+          echo "== authenticated /chat/completions probe =="
+          chat_payload=$(
+            jq -nc --arg model "$QWEN_MODEL" \
+              '{model: $model, messages: [{role: "user", content: "ping"}], max_tokens: 1}'
+          )
+          curl -sS \
+            --connect-timeout 10 \
+            --max-time 40 \
+            -H "Authorization: Bearer $OPENAI_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d "$chat_payload" \
+            -o /tmp/chat.json \
+            -w "http_code=%{http_code}\nremote_ip=%{remote_ip}\ntime_connect=%{time_connect}\ntime_appconnect=%{time_appconnect}\ntime_total=%{time_total}\n" \
+            "$OPENAI_BASE_URL/chat/completions"
+
+          echo "== chat response preview =="
+          head -c 1000 /tmp/chat.json
+          echo
+
       - name: Run incremental translation sync
         working-directory: ./website
         env:

--- a/.github/workflows/daily-translate.yml
+++ b/.github/workflows/daily-translate.yml
@@ -1,8 +1,9 @@
 name: Daily Incremental Translation
 
-# Runs the translator's incremental `sync` once a day, then (if anything
+# Runs the translator's incremental `sync` on demand, then (if anything
 # changed) commits the new translations to main, rebuilds the site and
-# deploys it — all in one job.
+# deploys it — all in one job. The daily schedule is disabled while the
+# translation API is unstable from github-hosted runners.
 #
 # Prerequisites (set in repo Settings → Secrets and variables → Actions):
 #   - Secret  TRANSLATE_API_KEY : a PUBLIC, cloud-reachable model API key
@@ -20,9 +21,6 @@ name: Daily Incremental Translation
 # github-actions bot to bypass protection, or switch the push step to a PR.
 
 on:
-  schedule:
-    # 20:00 UTC == 04:00 Asia/Shanghai (next day). Adjust as you like.
-    - cron: "0 20 * * *"
   workflow_dispatch: {}
 
 permissions:

--- a/translator/src/sync.ts
+++ b/translator/src/sync.ts
@@ -315,6 +315,8 @@ export class SyncManager {
         };
       }
 
+      this.ensureCommitAvailable(tempDir, lastSync.commit);
+
       // 获取变更文件
       const changedFiles = execSync(
         `cd ${tempDir} && git diff --name-only ${lastSync.commit} HEAD -- ${this.docsPath}/`,
@@ -337,6 +339,46 @@ export class SyncManager {
     } finally {
       // 清理临时目录在需要时取消注释
       // await fs.remove(tempDir);
+    }
+  }
+
+  private ensureCommitAvailable(repoPath: string, commit: string): void {
+    try {
+      execSync(`cd ${repoPath} && git cat-file -e ${commit}^{commit}`, {
+        stdio: "ignore",
+      });
+      return;
+    } catch {
+      console.log(
+        chalk.yellow(
+          `⚠️  同步基线 ${commit.slice(0, 8)} 不在浅克隆历史中，正在补全源仓库历史...`
+        )
+      );
+    }
+
+    const isShallow = execSync(
+      `cd ${repoPath} && git rev-parse --is-shallow-repository`,
+      { encoding: "utf8" }
+    ).trim();
+
+    if (isShallow === "true") {
+      execSync(`cd ${repoPath} && git fetch --unshallow origin ${this.branch}`, {
+        stdio: "inherit",
+      });
+    } else {
+      execSync(`cd ${repoPath} && git fetch origin ${this.branch}`, {
+        stdio: "inherit",
+      });
+    }
+
+    try {
+      execSync(`cd ${repoPath} && git cat-file -e ${commit}^{commit}`, {
+        stdio: "ignore",
+      });
+    } catch {
+      throw new Error(
+        `同步基线 ${commit} 不存在于源仓库历史中，无法计算增量变更`
+      );
     }
   }
 

--- a/translator/src/sync.ts
+++ b/translator/src/sync.ts
@@ -444,15 +444,23 @@ export class SyncManager {
   async translateChangedFiles(
     changedFiles: string[]
   ): Promise<Record<string, TranslationResult>> {
+    const languageConcurrency = Math.max(
+      1,
+      Math.min(
+        this.targetLanguages.length,
+        parseInt(process.env.QWEN_TRANSLATION_CONCURRENCY || "", 10) || 2
+      )
+    );
     console.log(
-      chalk.yellow(`🌍 开始并行翻译 ${this.targetLanguages.length} 种语言...`)
+      chalk.yellow(
+        `🌍 开始翻译 ${this.targetLanguages.length} 种语言（并发: ${languageConcurrency}）...`
+      )
     );
 
     // 在并行翻译前构造翻译器（此处会校验 OPENAI_API_KEY，缺失则尽早抛错）
     const translator = this.getTranslator();
 
-    // 并行翻译所有语言
-    const languagePromises = this.targetLanguages.map(async (language) => {
+    const translateLanguage = async (language: string) => {
       const result: TranslationResult = {
         success: 0,
         failed: 0,
@@ -531,10 +539,18 @@ export class SyncManager {
       );
 
       return { language, result };
-    });
+    };
 
-    // 等待所有语言翻译完成
-    const languageResults = await Promise.all(languagePromises);
+    // 限制语言级并发，避免云端兼容接口在多路长输出请求下提前断流。
+    const languageResults: {
+      language: string;
+      result: TranslationResult;
+    }[] = [];
+    for (let i = 0; i < this.targetLanguages.length; i += languageConcurrency) {
+      const batch = this.targetLanguages.slice(i, i + languageConcurrency);
+      const batchResults = await Promise.all(batch.map(translateLanguage));
+      languageResults.push(...batchResults);
+    }
 
     // 整理结果
     const results: Record<string, TranslationResult> = {};

--- a/translator/src/translator.ts
+++ b/translator/src/translator.ts
@@ -29,6 +29,7 @@ export class DocumentTranslator {
   private apiConfig: TranslatorConfig;
   private translationCache: Map<string, string>;
   private projectRoot: string;
+  private maxRetries: number;
 
   constructor(options: TranslationOptions = {}) {
     this.projectRoot = options.projectRoot || process.cwd();
@@ -60,6 +61,8 @@ export class DocumentTranslator {
       temperature: 0.1, // Low temperature for consistent translations
       chunkChars,
     };
+    this.maxRetries =
+      parseInt(process.env.QWEN_API_MAX_RETRIES || "", 10) || 4;
 
     // Translation cache
     this.translationCache = new Map<string, string>();
@@ -320,8 +323,7 @@ ${content}`;
     retryCount = 0,
     sliceMode = false
   ): Promise<string> {
-    const maxRetries = 3;
-    const baseDelay = 1000; // 1 second base delay
+    const baseDelay = 2000; // 2 second base delay
 
     try {
       const completion = await this.openai.chat.completions.create({
@@ -341,11 +343,15 @@ ${content}`;
 
       // An empty response on non-trivial input is almost always a transient
       // model hiccup; retry rather than silently dropping the content.
-      if (result.length === 0 && prompt.length > 200 && retryCount < maxRetries) {
-        const delay = baseDelay * Math.pow(2, retryCount);
+      if (
+        result.length === 0 &&
+        prompt.length > 200 &&
+        retryCount < this.maxRetries
+      ) {
+        const delay = this.getRetryDelay(baseDelay, retryCount);
         console.log(
           chalk.yellow(
-            `    ⏳ Empty response, retrying in ${delay / 1000}s (${retryCount + 1}/${maxRetries})`
+            `    ⏳ Empty response, retrying in ${Math.round(delay / 1000)}s (${retryCount + 1}/${this.maxRetries})`
           )
         );
         await new Promise((resolve) => setTimeout(resolve, delay));
@@ -359,12 +365,11 @@ ${content}`;
 
       return result;
     } catch (error: any) {
-      // Special handling for 429 errors
-      if (error.status === 429 && retryCount < maxRetries) {
-        const delay = baseDelay * Math.pow(2, retryCount); // Exponential backoff
+      if (this.isRetriableApiError(error) && retryCount < this.maxRetries) {
+        const delay = this.getRetryDelay(baseDelay, retryCount);
         console.log(
           chalk.yellow(
-            `    ⏳ Rate limited, retrying in ${delay / 1000}s (${retryCount + 1}/${maxRetries})`
+            `    ⏳ Transient API error (${error.message}), retrying in ${Math.round(delay / 1000)}s (${retryCount + 1}/${this.maxRetries})`
           )
         );
         await new Promise((resolve) => setTimeout(resolve, delay));
@@ -385,6 +390,43 @@ ${content}`;
         throw new Error(`Request configuration error: ${error.message}`);
       }
     }
+  }
+
+  private getRetryDelay(baseDelay: number, retryCount: number): number {
+    const jitter = Math.floor(Math.random() * 1000);
+    return baseDelay * Math.pow(2, retryCount) + jitter;
+  }
+
+  private isRetriableApiError(error: any): boolean {
+    const status = Number(error?.status);
+    if (status === 408 || status === 429 || status >= 500) {
+      return true;
+    }
+
+    const code = String(error?.code || "");
+    if (
+      [
+        "ECONNRESET",
+        "ETIMEDOUT",
+        "EAI_AGAIN",
+        "UND_ERR_SOCKET",
+        "UND_ERR_HEADERS_TIMEOUT",
+        "UND_ERR_BODY_TIMEOUT",
+      ].includes(code)
+    ) {
+      return true;
+    }
+
+    const message = String(error?.message || "").toLowerCase();
+    return [
+      "premature close",
+      "fetch failed",
+      "socket hang up",
+      "terminated",
+      "connection closed",
+      "connection reset",
+      "timeout",
+    ].some((needle) => message.includes(needle));
   }
 
   /**

--- a/translator/src/translator.ts
+++ b/translator/src/translator.ts
@@ -367,9 +367,10 @@ ${content}`;
     } catch (error: any) {
       if (this.isRetriableApiError(error) && retryCount < this.maxRetries) {
         const delay = this.getRetryDelay(baseDelay, retryCount);
+        const details = this.formatApiErrorDetails(error);
         console.log(
           chalk.yellow(
-            `    ⏳ Transient API error (${error.message}), retrying in ${Math.round(delay / 1000)}s (${retryCount + 1}/${this.maxRetries})`
+            `    ⏳ Transient API error (${details}), retrying in ${Math.round(delay / 1000)}s (${retryCount + 1}/${this.maxRetries})`
           )
         );
         await new Promise((resolve) => setTimeout(resolve, delay));
@@ -398,15 +399,16 @@ ${content}`;
   }
 
   private isRetriableApiError(error: any): boolean {
-    const status = Number(error?.status);
+    const status = Number(error?.status || error?.cause?.status);
     if (status === 408 || status === 429 || status >= 500) {
       return true;
     }
 
-    const code = String(error?.code || "");
+    const code = String(error?.code || error?.cause?.code || "");
     if (
       [
         "ECONNRESET",
+        "ECONNREFUSED",
         "ETIMEDOUT",
         "EAI_AGAIN",
         "UND_ERR_SOCKET",
@@ -417,8 +419,9 @@ ${content}`;
       return true;
     }
 
-    const message = String(error?.message || "").toLowerCase();
+    const message = this.formatApiErrorDetails(error).toLowerCase();
     return [
+      "connection error",
       "premature close",
       "fetch failed",
       "socket hang up",
@@ -427,6 +430,21 @@ ${content}`;
       "connection reset",
       "timeout",
     ].some((needle) => message.includes(needle));
+  }
+
+  private formatApiErrorDetails(error: any): string {
+    const parts = [
+      error?.name,
+      error?.code,
+      error?.message,
+      error?.cause?.name,
+      error?.cause?.code,
+      error?.cause?.message,
+    ]
+      .filter(Boolean)
+      .map(String);
+
+    return parts.length > 0 ? parts.join(": ") : "unknown error";
   }
 
   /**


### PR DESCRIPTION
## Summary
- retry transient translation API failures such as `Premature close`, fetch disconnects, 408/429/5xx, and socket timeouts
- add `QWEN_TRANSLATION_CONCURRENCY` to bound language-level translation concurrency
- set the daily translation workflow to run translation one language at a time with API retries enabled

## Failure investigated
Latest failed run: https://github.com/QwenLM/qwen-code-docs/actions/runs/28320824593

The npm install issue is fixed: translator and website dependency steps passed. The new failure is in `Run incremental translation sync`: every translation request failed with `Invalid response body ... Premature close` against the MaaS compatible endpoint. Because the workflow correctly fails when any file fails to translate, it exited before commit/deploy.

## Verification
- `npm run build` in `translator`
- `node ../translator/bin/qwen-translator sync --detect-only` in `website`