### PR TITLE
ci: update GitHub Actions runtime versions

### DIFF
--- a/.github/workflows/daily-translate.yml
+++ b/.github/workflows/daily-translate.yml
@@ -38,6 +38,9 @@ jobs:
     runs-on: [self-hosted, Linux, X64, ecs-qwen]
     timeout-minutes: 90
     steps:
+      - name: Configure Git transport
+        run: git config --global http.version HTTP/1.1
+
       - name: Checkout workflow ref
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/daily-translate.yml
+++ b/.github/workflows/daily-translate.yml
@@ -43,6 +43,10 @@ jobs:
         with:
           ref: ${{ github.ref }}
           fetch-depth: 1
+          sparse-checkout: |
+            .github
+            translator
+            website
 
       - name: Install Node.js
         uses: actions/setup-node@v3

--- a/.github/workflows/daily-translate.yml
+++ b/.github/workflows/daily-translate.yml
@@ -1,9 +1,9 @@
 name: Daily Incremental Translation
 
-# Runs the translator's incremental `sync` on demand, then (if anything
+# Runs the translator's incremental `sync` once a day, then (if anything
 # changed) commits the new translations to main, rebuilds the site and
-# deploys it — all in one job. The daily schedule is disabled while the
-# translation API is unstable from github-hosted runners.
+# deploys it — all in one job. It uses a self-hosted runner so long translation
+# requests can use a network path that is stable for the MaaS endpoint.
 #
 # Prerequisites (set in repo Settings → Secrets and variables → Actions):
 #   - Secret  TRANSLATE_API_KEY : a PUBLIC, cloud-reachable model API key
@@ -21,6 +21,9 @@ name: Daily Incremental Translation
 # github-actions bot to bypass protection, or switch the push step to a PR.
 
 on:
+  schedule:
+    # 20:00 UTC == 04:00 Asia/Shanghai (next day). Adjust as you like.
+    - cron: "0 20 * * *"
   workflow_dispatch: {}
 
 permissions:
@@ -32,7 +35,7 @@ concurrency:
 
 jobs:
   translate-and-deploy:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 90
     steps:
       - name: Checkout workflow ref

--- a/.github/workflows/daily-translate.yml
+++ b/.github/workflows/daily-translate.yml
@@ -61,7 +61,7 @@ jobs:
         env:
           OPENAI_API_KEY: ${{ secrets.TRANSLATE_CODING_PLAN_API_KEY }}
           OPENAI_BASE_URL: https://coding.dashscope.aliyuncs.com/v1
-          QWEN_MODEL: deepseek-v4-flash
+          QWEN_MODEL: qwen3.7-plus
           # Keep each response moderate; larger docs auto-chunk from this cap.
           QWEN_MAX_TOKENS: "8192"
           # The MaaS compatible endpoint can close long responses when all

--- a/.github/workflows/daily-translate.yml
+++ b/.github/workflows/daily-translate.yml
@@ -33,7 +33,7 @@ concurrency:
 jobs:
   translate-and-deploy:
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 180
     steps:
       - name: Checkout workflow ref
         uses: actions/checkout@v4

--- a/.github/workflows/daily-translate.yml
+++ b/.github/workflows/daily-translate.yml
@@ -2,13 +2,10 @@ name: Daily Incremental Translation
 
 # Runs the translator's incremental `sync` once a day, then (if anything
 # changed) commits the new translations to main, rebuilds the site and
-# deploys it — all in one job. It uses a self-hosted runner so long translation
-# requests can use a network path that is stable for the MaaS endpoint.
+# deploys it — all in one job.
 #
 # Prerequisites (set in repo Settings → Secrets and variables → Actions):
-#   - Secret  TRANSLATE_API_KEY : a PUBLIC, cloud-reachable model API key
-#                                 (Aliyun MaaS — github-hosted runners cannot
-#                                 reach the internal idealab endpoint).
+#   - Secret  TRANSLATE_CODING_PLAN_API_KEY : a cloud-reachable model API key
 #   Model / base URL are set as plain env below; change them if you switch
 #   providers. The incremental baseline lives in website/last-sync.json
 #   (tracked in git), so each run only translates what changed upstream.
@@ -35,21 +32,14 @@ concurrency:
 
 jobs:
   translate-and-deploy:
-    runs-on: [self-hosted, Linux, X64, ecs-qwen]
+    runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
-      - name: Configure Git transport
-        run: git config --global http.version HTTP/1.1
-
       - name: Checkout workflow ref
         uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
           fetch-depth: 1
-          sparse-checkout: |
-            .github
-            translator
-            website
 
       - name: Install Node.js
         uses: actions/setup-node@v3
@@ -69,8 +59,8 @@ jobs:
       - name: Run incremental translation sync
         working-directory: ./website
         env:
-          OPENAI_API_KEY: ${{ secrets.TRANSLATE_API_KEY }}
-          OPENAI_BASE_URL: https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1
+          OPENAI_API_KEY: ${{ secrets.TRANSLATE_CODING_PLAN_API_KEY }}
+          OPENAI_BASE_URL: https://coding.dashscope.aliyuncs.com/v1
           QWEN_MODEL: deepseek-v4-flash
           # Keep each response moderate; larger docs auto-chunk from this cap.
           QWEN_MAX_TOKENS: "8192"

--- a/.github/workflows/daily-translate.yml
+++ b/.github/workflows/daily-translate.yml
@@ -63,11 +63,11 @@ jobs:
           OPENAI_BASE_URL: https://coding.dashscope.aliyuncs.com/v1
           QWEN_MODEL: qwen3.7-plus
           # Keep each response moderate; larger docs auto-chunk from this cap.
-          QWEN_MAX_TOKENS: "8192"
+          QWEN_MAX_TOKENS: "32768"
           # The MaaS compatible endpoint can close long responses when all
           # target languages run at once. Keep CI conservative and let API
           # retries handle transient disconnects.
-          QWEN_TRANSLATION_CONCURRENCY: "1"
+          QWEN_TRANSLATION_CONCURRENCY: "6"
           QWEN_API_MAX_RETRIES: "4"
         run: |
           set -o pipefail

--- a/.github/workflows/daily-translate.yml
+++ b/.github/workflows/daily-translate.yml
@@ -35,7 +35,7 @@ concurrency:
 
 jobs:
   translate-and-deploy:
-    runs-on: self-hosted
+    runs-on: [self-hosted, Linux, X64, ecs-qwen]
     timeout-minutes: 90
     steps:
       - name: Checkout workflow ref

--- a/.github/workflows/daily-translate.yml
+++ b/.github/workflows/daily-translate.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Install Node.js
         uses: actions/setup-node@v3

--- a/.github/workflows/daily-translate.yml
+++ b/.github/workflows/daily-translate.yml
@@ -36,13 +36,13 @@ jobs:
     timeout-minutes: 180
     steps:
       - name: Checkout workflow ref
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.ref }}
           fetch-depth: 1
 
       - name: Install Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: 22
 
@@ -114,7 +114,7 @@ jobs:
 
       - name: Deploy to GitHub Pages
         if: steps.detect.outputs.changed == 'true' && github.ref_name == 'main'
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./website/out

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -14,15 +14,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Install Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: 22
-          run_install: false
 
       - name: Install dependencies
         run: npm ci --no-audit --no-fund
@@ -39,7 +38,7 @@ jobs:
           NODE_OPTIONS: --max-old-space-size=12288
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./website/out

--- a/translator/src/translator.ts
+++ b/translator/src/translator.ts
@@ -71,20 +71,25 @@ export class DocumentTranslator {
   }
 
   /**
-   * Translate entire document
+   * Translate entire document.
+   * Logs are buffered and flushed atomically so concurrent tasks never
+   * interleave their output.
    */
   async translateDocument(
     filePath: string,
     targetLang: string
   ): Promise<string> {
+    const logLines: string[] = [];
+    const log = (msg: string) => { logLines.push(msg); };
+
     try {
-      console.log(chalk.gray(`→ ${path.basename(filePath)} (${targetLang})`));
+      log(chalk.gray(`→ ${path.basename(filePath)} (${targetLang})`));
 
       const content = await fs.readFile(filePath, "utf-8");
       const parsedContent = parseMarkdown(content);
 
       // Full document translation (leverage large context models like deepseek-v4-flash)
-      console.log(
+      log(
         chalk.blue(
           `  ✓ Translating full document (${content.length} characters)`
         )
@@ -92,36 +97,52 @@ export class DocumentTranslator {
 
       const translatedContent = await this.translateContent(
         parsedContent.originalContent,
-        targetLang
+        targetLang,
+        path.basename(filePath),
+        log
       );
 
-      console.log(chalk.green(`✓ Completed ${path.basename(filePath)}`));
+      log(chalk.green(`✓ Completed ${path.basename(filePath)} (${targetLang})`));
       return translatedContent;
     } catch (error: any) {
-      console.error(chalk.red(`✗ Translation failed: ${error.message}`));
+      log(chalk.red(`✗ Translation failed: ${path.basename(filePath)} (${targetLang}): ${error.message}`));
       throw error;
+    } finally {
+      // Flush all collected logs in one atomic write so concurrent
+      // translations never interleave their progress lines.
+      if (logLines.length) {
+        process.stdout.write(logLines.join('\n') + '\n');
+      }
     }
   }
 
   /**
    * Translate text content
+   * @param label Optional label (e.g. filename) included in progress logs to
+   *              disambiguate output when multiple translations run concurrently.
+   * @param log   Logger function; defaults to console.log. Pass a buffered
+   *              logger to group output atomically.
    */
   async translateContent(
     content: string,
-    targetLang: string
+    targetLang: string,
+    label?: string,
+    log: (msg: string) => void = console.log
   ): Promise<string> {
     const cacheKey = `${content}-${targetLang}`;
     if (this.translationCache.has(cacheKey)) {
-      console.log(chalk.gray(`    ✓ Cached translation`));
+      log(chalk.gray(`    ✓ Cached translation`));
       return this.translationCache.get(cacheKey)!;
     }
 
     try {
       let translatedContent: string;
 
+      const logPrefix = label ? `${label} (${targetLang})` : `(${targetLang})`;
+
       if (content.length <= this.apiConfig.chunkChars) {
         // Small enough: translate in a single request (original behavior).
-        console.log(chalk.cyan(`    → Translating content (${targetLang})`));
+        log(chalk.cyan(`    → Translating content ${logPrefix}`));
         translatedContent = await this.callTranslationAPI(
           this.buildTranslationPrompt(content, targetLang),
           targetLang
@@ -131,9 +152,9 @@ export class DocumentTranslator {
         // and reassemble. Avoids silent truncation when the translation would
         // exceed the model's output-token limit.
         const slices = this.chunkMarkdown(content, this.apiConfig.chunkChars);
-        console.log(
+        log(
           chalk.cyan(
-            `    → Translating content (${targetLang}) in ${slices.length} slices`
+            `    → Translating content ${logPrefix} in ${slices.length} slices`
           )
         );
         const translatedSlices: string[] = [];
@@ -153,9 +174,7 @@ export class DocumentTranslator {
             );
           }
           translatedSlices.push(out);
-          console.log(
-            chalk.gray(`      ✓ slice ${i + 1}/${slices.length}`)
-          );
+          log(chalk.gray(`      ✓ slice ${i + 1}/${slices.length}`));
         }
         translatedContent = translatedSlices.join("\n");
       }
@@ -165,7 +184,7 @@ export class DocumentTranslator {
 
       return translatedContent;
     } catch (error: any) {
-      console.error(chalk.red(`    ✗ Translation failed: ${error.message}`));
+      log(chalk.red(`    ✗ Translation failed: ${error.message}`));
       throw error;
     }
   }


### PR DESCRIPTION
## Summary
- update checkout/setup-node actions to versions that run on Node 24
- update gh-pages deploy action to v4
- remove unsupported setup-node input from deploy workflow

## Validation
- parsed workflow YAML locally
- checked action metadata for Node 24 runtime and existing input compatibility