### PR TITLE
ci: update GitHub Actions runtime versions

### DIFF
--- a/.github/workflows/daily-translate.yml
+++ b/.github/workflows/daily-translate.yml
@@ -36,13 +36,13 @@ jobs:
     timeout-minutes: 90
     steps:
       - name: Checkout workflow ref
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.ref }}
           fetch-depth: 0
 
       - name: Install Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: 22
 
@@ -114,7 +114,7 @@ jobs:
 
       - name: Deploy to GitHub Pages
         if: steps.detect.outputs.changed == 'true' && github.ref_name == 'main'
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./website/out

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -14,15 +14,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Install Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: 22
-          run_install: false
 
       - name: Install dependencies
         run: npm ci --no-audit --no-fund
@@ -39,7 +38,7 @@ jobs:
           NODE_OPTIONS: --max-old-space-size=12288
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./website/out


### PR DESCRIPTION
## Summary
- update checkout/setup-node actions to versions that run on Node 24
- update gh-pages deploy action to v4
- remove unsupported setup-node input from deploy workflow

## Validation
- parsed workflow YAML locally
- checked action metadata for Node 24 runtime and existing input compatibility