### PR TITLE
fix: correct showcase index syntax across all languages

### DIFF
--- a/website/content/de/showcase/index.mdx
+++ b/website/content/de/showcase/index.mdx
@@ -1879,6 +1879,8 @@ export const showcaseItems = [
       { title: "Einstellungen durchsuchen", description: "Tippen Sie auf der Settings-Seite direkt ein Stichwort, um Einstellungen zu filtern." },
       { title: "Zur Status-Seite wechseln", description: "Wechseln Sie mit ←/→ zur Status-Seite, um Laufzeitinformationen zu sehen, ohne /status separat auszuführen." },
       { title: "Stats-Dashboard anzeigen", description: "Wechseln Sie zur Stats-Seite und navigieren Sie mit Tab zwischen den Untertabs Session / Activity / Efficiency." },
+    ],
+  },
   {
     id: "code-review-demo",
     title: "9 KI-Reviewer prüfen deinen Code gleichzeitig",
@@ -1895,7 +1897,7 @@ export const showcaseItems = [
       { title: "PR-Review & Kommentare", description: "Starte `/review <PR number> --comment`, um eine Remote-PR zu reviewen. Wechsel zu GitHub und finde Inline-Kommentare direkt in den Codezeilen.", command: "/review <PR number> --comment" },
     ],
   },
-];
+]
 
 
 <VideoShowcaseIndex

--- a/website/content/en/showcase/index.mdx
+++ b/website/content/en/showcase/index.mdx
@@ -1879,6 +1879,8 @@ export const showcaseItems = [
       { title: "Search Settings", description: "Start typing on the Settings tab to filter settings by keyword." },
       { title: "Switch to the Status Tab", description: "Use ←/→ to switch to the Status tab for runtime info — no need to run /status separately." },
       { title: "View the Stats Dashboard", description: "Switch to the Stats tab and press Tab to cycle through Session / Activity / Efficiency sub-tabs." },
+    ],
+  },
   {
     id: "code-review-demo",
     title: "9 AI Reviewers, Checking Your Code Simultaneously",
@@ -1895,7 +1897,7 @@ export const showcaseItems = [
       { title: "PR Review & Comment", description: "Run `/review <PR number> --comment` to review a remote PR. Switch to GitHub and see inline comments posted right on the code lines.", command: "/review <PR number> --comment" },
     ],
   },
-];
+]
 
 <VideoShowcaseIndex
   items={showcaseItems}

--- a/website/content/fr/showcase/index.mdx
+++ b/website/content/fr/showcase/index.mdx
@@ -1879,6 +1879,8 @@ export const showcaseItems = [
       { title: "Rechercher un paramètre", description: "Tapez un mot-clé dans la page Settings pour filtrer les paramètres instantanément." },
       { title: "Passer à l'onglet Status", description: "Utilisez ←/→ pour passer à l'onglet Status et consulter les informations d'exécution sans lancer /status séparément." },
       { title: "Consulter le tableau de bord Stats", description: "Passez à l'onglet Stats et utilisez Tab pour basculer entre les sous-onglets Session / Activity / Efficiency." },
+    ],
+  },
   {
     id: "code-review-demo",
     title: "9 agents IA qui reviewent votre code en même temps",
@@ -1895,7 +1897,7 @@ export const showcaseItems = [
       { title: "Revue de PR & commentaires", description: "Lancez `/review <PR number> --comment` pour reviewer une PR à distance. Passez sur GitHub et retrouvez les commentaires inline directement sur les lignes de code.", command: "/review <PR number> --comment" },
     ],
   },
-];
+]
 
 
 <VideoShowcaseIndex

--- a/website/content/ja/showcase/index.mdx
+++ b/website/content/ja/showcase/index.mdx
@@ -1880,7 +1880,7 @@ export const showcaseItems = [
       { title: "Status ページに切り替え", description: "←/→ で Status ページに切り替え、ランタイム情報を確認できます。/status を個別に実行する必要はありません。" },
       { title: "Stats ダッシュボードを表示", description: "Stats ページに切り替え、Tab キーで Session / Activity / Efficiency のサブタブを切り替えます。" },
     ],
-  }
+  },
   {
     id: "code-review-demo",
     title: "9人のAIレビュアーが同時にコードをチェック",
@@ -1897,7 +1897,7 @@ export const showcaseItems = [
       { title: "PRレビュー＆コメント", description: "`/review <PR number> --comment` でリモートPRをレビュー。GitHub に切り替えると、コード行に直接インラインコメントが投稿されています。", command: "/review <PR number> --comment" },
     ],
   },
-];
+]
 
 
 <VideoShowcaseIndex

--- a/website/content/pt-BR/showcase/index.mdx
+++ b/website/content/pt-BR/showcase/index.mdx
@@ -1880,7 +1880,7 @@ export const showcaseItems = [
       { title: "Alternar para a aba Status", description: "Use ←/→ para alternar para a aba Status e ver informações de runtime — sem precisar rodar /status separadamente." },
       { title: "Ver o painel de Stats", description: "Alternar para a aba Stats e pressione Tab para navegar entre as sub-abas Session / Activity / Efficiency." },
     ],
-  }
+  },
   {
     id: "code-review-demo",
     title: "9 revisores de IA analisando seu código ao mesmo tempo",
@@ -1897,7 +1897,7 @@ export const showcaseItems = [
       { title: "Revisão de PR & comentários", description: "Execute `/review <PR number> --comment` para revisar um PR remoto. Abra o GitHub e veja os comentários inline diretamente nas linhas de código.", command: "/review <PR number> --comment" },
     ],
   },
-];
+]
 
 <VideoShowcaseIndex
   items={showcaseItems}

--- a/website/content/ru/showcase/index.mdx
+++ b/website/content/ru/showcase/index.mdx
@@ -1879,6 +1879,8 @@ export const showcaseItems = [
       { title: "Поиск настроек", description: "На вкладке Settings начните вводить ключевые слова для фильтрации настроек." },
       { title: "Переключение на вкладку Status", description: "Используйте ←/→ для переключения на вкладку Status и просмотра информации о среде выполнения — без отдельного запуска /status." },
       { title: "Просмотр дашборда Stats", description: "Переключитесь на вкладку Stats и используйте Tab для переключения между подразделами Session / Activity / Efficiency." },
+    ],
+  },
   {
     id: "code-review-demo",
     title: "9 ИИ-ревьюеров проверяют ваш код одновременно",
@@ -1895,8 +1897,7 @@ export const showcaseItems = [
       { title: "Ревью PR и комментарии", description: "Запустите `/review <PR number> --comment` для ревью удалённого PR. Откройте GitHub и увидите инлайн-комментарии прямо в строках кода.", command: "/review <PR number> --comment" },
     ],
   },
-];
-
+]
 
 <VideoShowcaseIndex
   items={showcaseItems}

--- a/website/content/zh/showcase/index.mdx
+++ b/website/content/zh/showcase/index.mdx
@@ -1879,6 +1879,8 @@ export const showcaseItems = [
       { title: "搜索设置项", description: "在 Settings 页直接输入关键词筛选设置项。" },
       { title: "切换到 Status 页", description: "用 ←/→ 切换到 Status 页查看运行时信息，不用单独跑 /status。" },
       { title: "查看 Stats 仪表盘", description: "切换到 Stats 页，按 Tab 切换 Session / Activity / Efficiency 子标签。" },
+    ],
+  },
   {
     id: "code-review-demo",
     title: "9 个 AI 审查员，同时帮你看代码",
@@ -1895,7 +1897,7 @@ export const showcaseItems = [
       { title: "PR 审查并评论", description: "运行 `/review <PR number> --comment` 审查远程 PR，切到 GitHub 查看行内批注，审查意见直接写在代码行上。", command: "/review <PR number> --comment" },
     ],
   },
-];
+]
 
 
 <VideoShowcaseIndex


### PR DESCRIPTION
修复所有语言版本 showcase/index.mdx 中的语法错误（缺失闭合括号与逗号），确保构建正常。