### PR TITLE
feat(website): add Korean (ko) locale

### DIFF
--- a/website/app/[lang]/layout.tsx
+++ b/website/app/[lang]/layout.tsx
@@ -20,7 +20,7 @@ type LayoutProps = Readonly<{
   }>;
 }>;
 
-const LOCALES = ["en", "zh", "de", "fr", "ru", "ja", "pt-BR"];
+const LOCALES = ["en", "zh", "de", "fr", "ru", "ja", "pt-BR", "ko"];
 
 const LanguageLayout: FC<LayoutProps> = async ({ children, params }) => {
   const { lang } = await params;
@@ -74,6 +74,7 @@ const LanguageLayout: FC<LayoutProps> = async ({ children, params }) => {
     lang === "fr" ? "Rechercher dans la documentation..." :
     lang === "ru" ? "Поиск в документации..." :
     lang === "pt-BR" ? "Pesquisar documentação..." :
+    lang === "ko" ? "문서 검색..." :
     "Search documentation..."
   } lang={lang} className='shrink-0' />
       <GitHubStarLink projectLink='https://github.com/QwenLM/qwen-code' className='shrink-0' />
@@ -96,6 +97,7 @@ const LanguageLayout: FC<LayoutProps> = async ({ children, params }) => {
         { locale: "ru", name: "Русский" },
         { locale: "ja", name: "日本語" },
         { locale: "pt-BR", name: "Português (BR)" },
+        { locale: "ko", name: "한국어" },
       ]}
       search={false}
       sidebar={{ defaultMenuCollapseLevel: 1 }}

--- a/website/app/sitemap.ts
+++ b/website/app/sitemap.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { execSync } from "node:child_process";
 
-const LOCALES = ["en", "zh", "de", "fr", "ru", "ja", "pt-BR"] as const;
+const LOCALES = ["en", "zh", "de", "fr", "ru", "ja", "pt-BR", "ko"] as const;
 
 export function generateStaticParams() {
   return [{ __metadata_id__: [] }];

--- a/website/next.config.mjs
+++ b/website/next.config.mjs
@@ -18,7 +18,7 @@ export default withNextra({
   basePath: assetPrefix,
   assetPrefix: assetPrefix,
   i18n: {
-    locales: ["en", "zh", "de", "fr", "ru", "ja", "pt-BR"],
+    locales: ["en", "zh", "de", "fr", "ru", "ja", "pt-BR", "ko"],
     defaultLocale: "en",
   },
   eslint: {

--- a/website/scripts/set-html-lang.js
+++ b/website/scripts/set-html-lang.js
@@ -21,6 +21,7 @@ const langMap = {
   ru: 'ru',
   ja: 'ja',
   'pt-BR': 'pt-BR',
+  ko: 'ko',
 };
 
 function processDirectory(dirPath, lang) {

--- a/website/src/components/blog-index-client.tsx
+++ b/website/src/components/blog-index-client.tsx
@@ -50,6 +50,10 @@ const BLOG_COPY: Record<string, { title: string; description: string }> = {
     title: "Blog Qwen Code",
     description: "Atualizações de programação com IA, lançamentos, fluxos de trabalho e guias práticos para desenvolvedores.",
   },
+  ko: {
+    title: "Qwen Code 블로그",
+    description: "AI 코딩 소식, 제품 릴리스, 워크플로우, 개발자를 위한 실용 가이드.",
+  },
 };
 
 export const BlogIndexClient = ({ posts, lang }: BlogIndexClientProps) => {

--- a/website/src/components/blog-post-header.tsx
+++ b/website/src/components/blog-post-header.tsx
@@ -35,6 +35,7 @@ export const BlogPostHeader: React.FC<BlogPostHeaderProps> = ({
     ja: "ブログに戻る",
     ru: "Назад в блог",
     'pt-BR': "Voltar ao Blog",
+    ko: "블로그로 돌아가기",
   };
 
   const blogPath = `/${langPrefix}/blog`;

--- a/website/src/components/custom-navbar.tsx
+++ b/website/src/components/custom-navbar.tsx
@@ -81,7 +81,7 @@ const getUserLanguage = (): string => {
 
   if (pathSegments.length > 0) {
     const possibleLang = pathSegments[0];
-    const supportedLanguages = ["en", "zh", "de", "fr", "ru", "ja", "pt-BR"];
+    const supportedLanguages = ["en", "zh", "de", "fr", "ru", "ja", "pt-BR", "ko"];
     if (supportedLanguages.includes(possibleLang)) {
       return possibleLang;
     }
@@ -95,6 +95,7 @@ const getUserLanguage = (): string => {
   if (browserLang.startsWith("ru")) return "ru";
   if (browserLang.startsWith("ja")) return "ja";
   if (browserLang.startsWith("pt")) return "pt-BR";
+  if (browserLang.startsWith("ko")) return "ko";
 
   return "en"; // 默认英文
 };

--- a/website/src/components/language-dropdown.tsx
+++ b/website/src/components/language-dropdown.tsx
@@ -14,6 +14,7 @@ const languages = [
   { locale: "ru", name: "Русский", flag: "🇷🇺" },
   { locale: "ja", name: "日本語", flag: "🇯🇵" },
   { locale: "pt-BR", name: "Português (BR)", flag: "🇧🇷" },
+  { locale: "ko", name: "한국어", flag: "🇰🇷" },
 ];
 
 const languageLocales = languages.map((language) => language.locale);

--- a/website/src/components/locale-anchor.tsx
+++ b/website/src/components/locale-anchor.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import React from "react";
 
-const LOCALES = ["en", "zh", "de", "fr", "ru", "ja", "pt-BR"] as const;
+const LOCALES = ["en", "zh", "de", "fr", "ru", "ja", "pt-BR", "ko"] as const;
 type Locale = (typeof LOCALES)[number];
 
 function LinkArrowIcon(props: React.SVGProps<SVGSVGElement>) {

--- a/website/src/lib/structured-data.ts
+++ b/website/src/lib/structured-data.ts
@@ -28,7 +28,7 @@ export function getSiteStructuredData(siteUrl: string) {
       publisher: {
         "@id": organizationId,
       },
-      inLanguage: ["en", "zh", "de", "fr", "ru", "ja", "pt-BR"],
+      inLanguage: ["en", "zh", "de", "fr", "ru", "ja", "pt-BR", "ko"],
     },
   ];
 

--- a/website/translation.config.json
+++ b/website/translation.config.json
@@ -3,7 +3,7 @@
   "sourceRepo": "https://github.com/QwenLM/qwen-code.git",
   "docsPath": "docs",
   "sourceLanguage": "en",
-  "targetLanguages": ["zh", "de", "fr", "ru", "ja", "pt-BR"],
+  "targetLanguages": ["zh", "de", "fr", "ru", "ja", "pt-BR", "ko"],
   "outputDir": "content",
   "branch": "main",
   "excludeFromTranslation": [


### PR DESCRIPTION
## What

Adds Korean (`ko`) to the documentation site's language set, so that:

- the daily incremental translation workflow generates and deploys `content/ko/**`
- the language switcher offers **한국어** and `/ko/...` routes render correctly

## Why

The site currently ships `zh`, `de`, `fr`, `ru`, `ja`, and `pt-BR`, but not Korean. This wires `ko` through every place the locale list is hardcoded so the existing auto-translation pipeline can pick it up.

## Changes

The locale is registered consistently across all locale lists and UI maps:

| File | Change |
|---|---|
| `website/translation.config.json` | add `ko` to `targetLanguages` |
| `website/next.config.mjs` | add `ko` to `i18n.locales` |
| `website/app/[lang]/layout.tsx` | add `ko` to `LOCALES`, the i18n name map (`한국어`), and the search placeholder |
| `website/app/sitemap.ts` | add `ko` to `LOCALES` |
| `website/src/components/locale-anchor.tsx` | add `ko` to `LOCALES` |
| `website/src/components/custom-navbar.tsx` | add `ko` to `supportedLanguages` and browser-language detection |
| `website/scripts/set-html-lang.js` | add `ko` to `langMap` |
| `website/src/lib/structured-data.ts` | add `ko` to `inLanguage` |
| `website/src/components/language-dropdown.tsx` | add `{ locale: "ko", name: "한국어", flag: "🇰🇷" }` |
| `website/src/components/blog-post-header.tsx` | add Korean "back to blog" text |
| `website/src/components/blog-index-client.tsx` | add Korean blog-index copy |

## Notes

- Korean document content (`content/ko/**`) is intentionally **not** included in this PR — it is produced by the repo's Qwen AI translation workflow (`.github/workflows/daily-translate.yml`). This PR only registers the locale so that pipeline can generate it. A maintainer may want to run the translate workflow (or trigger it via `workflow_dispatch`) once after merge to populate `content/ko/**`.
- Once `ko` docs are live at `qwenlm.github.io/qwen-code-docs/ko/...`, the `한국어` link can be added to the language switcher in the main [`QwenLM/qwen-code`](https://github.com/QwenLM/qwen-code) `README.md`.
