### PR TITLE
ci: shard and harden daily translations

### DIFF
--- a/.github/scripts/merge-translation-artifacts.mjs
+++ b/.github/scripts/merge-translation-artifacts.mjs
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+async function readJson(file) {
+  return JSON.parse(await fs.readFile(file, "utf8"));
+}
+
+async function writeJson(file, value) {
+  await fs.writeFile(file, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+export async function mergeTranslationArtifacts(
+  artifactsRoot,
+  websiteRoot,
+  languages,
+  shardCount,
+) {
+  if (!Array.isArray(languages) || languages.length === 0) {
+    throw new Error("At least one target language is required");
+  }
+  if (!Number.isInteger(shardCount) || shardCount < 1) {
+    throw new Error(`Invalid shard count: ${shardCount}`);
+  }
+  let commit;
+  let sourceLanguage;
+  let totalFiles;
+  let deletedFiles;
+  let newestTimestamp = "";
+  let syncRecord;
+  const translatedFiles = {};
+  let successCount = 0;
+  let failedCount = 0;
+
+  for (const language of languages) {
+    const languageResult = { success: [], failed: [] };
+    const seenFiles = new Set();
+
+    for (let shardIndex = 0; shardIndex < shardCount; shardIndex++) {
+      const label = `${language} shard ${shardIndex + 1}/${shardCount}`;
+      const artifactRoot = path.join(
+        artifactsRoot,
+        `translation-${language}-${shardIndex}`,
+      );
+      const record = await readJson(path.join(artifactRoot, "last-sync.json"));
+      const changelog = await readJson(
+        path.join(artifactRoot, "translation-changelog.json"),
+      );
+      const entry = changelog[0];
+      const result = entry?.translatedFiles?.[language];
+
+      if (!entry || !result) {
+        throw new Error(`Artifact for ${label} has no matching sync result`);
+      }
+      if (
+        entry.shard?.index !== shardIndex ||
+        entry.shard?.count !== shardCount
+      ) {
+        throw new Error(`Artifact for ${label} has invalid shard metadata`);
+      }
+      if (entry.commit !== record.commit) {
+        throw new Error(`Artifact for ${label} has inconsistent commits`);
+      }
+      if (commit && commit !== entry.commit) {
+        throw new Error(
+          `Translation artifacts target different commits: ${commit} and ${entry.commit}`,
+        );
+      }
+      if (sourceLanguage && sourceLanguage !== entry.sourceLanguage) {
+        throw new Error(
+          `Artifact for ${label} has a different source language`,
+        );
+      }
+      if (totalFiles !== undefined && totalFiles !== entry.stats.totalFiles) {
+        throw new Error(`Artifact for ${label} has a different file count`);
+      }
+      const artifactDeletedFiles = [...(entry.deletedFiles || [])].sort();
+      if (
+        artifactDeletedFiles.some(
+          (file) =>
+            typeof file !== "string" ||
+            path.isAbsolute(file) ||
+            file.split(/[\\/]/).includes(".."),
+        )
+      ) {
+        throw new Error(`Artifact for ${label} has an unsafe deleted path`);
+      }
+      if (
+        deletedFiles &&
+        JSON.stringify(deletedFiles) !== JSON.stringify(artifactDeletedFiles)
+      ) {
+        throw new Error(`Artifact for ${label} has a different deletion list`);
+      }
+      if (
+        entry.stats.languages !== 1 ||
+        entry.stats.successCount !== result.success.length ||
+        entry.stats.failedCount !== result.failed.length
+      ) {
+        throw new Error(`Artifact for ${label} has inconsistent statistics`);
+      }
+      if (result.failed.length !== 0) {
+        throw new Error(`Artifact for ${label} contains failed translations`);
+      }
+      for (const file of result.success) {
+        if (seenFiles.has(file)) {
+          throw new Error(`Artifact for ${label} repeats ${file}`);
+        }
+        seenFiles.add(file);
+        languageResult.success.push(file);
+      }
+
+      commit = entry.commit;
+      sourceLanguage = entry.sourceLanguage;
+      totalFiles = entry.stats.totalFiles;
+      deletedFiles = artifactDeletedFiles;
+      newestTimestamp = [newestTimestamp, entry.timestamp].sort().at(-1);
+      syncRecord =
+        !syncRecord || record.timestamp > syncRecord.timestamp
+          ? record
+          : syncRecord;
+
+      const contentRoot = path.join(artifactRoot, "content", language);
+      try {
+        await fs.access(contentRoot);
+        await fs.cp(contentRoot, path.join(websiteRoot, "content", language), {
+          recursive: true,
+          force: true,
+        });
+      } catch (error) {
+        if (error.code !== "ENOENT") throw error;
+      }
+    }
+
+    translatedFiles[language] = languageResult;
+    successCount += languageResult.success.length;
+    failedCount += languageResult.failed.length;
+    for (const file of deletedFiles || []) {
+      await fs.rm(path.join(websiteRoot, "content", language, file), {
+        force: true,
+      });
+    }
+  }
+
+  const changelogPath = path.join(websiteRoot, "translation-changelog.json");
+  const changelog = await readJson(changelogPath);
+  changelog.unshift({
+    timestamp: newestTimestamp,
+    commit,
+    sourceLanguage,
+    translatedFiles,
+    deletedFiles: deletedFiles || [],
+    stats: {
+      totalFiles,
+      languages: languages.length,
+      successCount,
+      failedCount,
+    },
+  });
+
+  await writeJson(changelogPath, changelog.slice(0, 100));
+  await writeJson(path.join(websiteRoot, "last-sync.json"), syncRecord);
+}
+
+if (fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  const artifactsRoot = path.resolve(
+    process.argv[2] || ".translation-artifacts",
+  );
+  const websiteRoot = path.resolve(process.argv[3] || "website");
+  const config = await readJson(
+    path.join(websiteRoot, "translation.config.json"),
+  );
+  const shardCount = Number(process.argv[4]);
+  await mergeTranslationArtifacts(
+    artifactsRoot,
+    websiteRoot,
+    config.targetLanguages,
+    shardCount,
+  );
+  console.log(
+    `Merged ${config.targetLanguages.length * shardCount} translation artifacts`,
+  );
+}

--- a/.github/scripts/merge-translation-artifacts.test.mjs
+++ b/.github/scripts/merge-translation-artifacts.test.mjs
@@ -1,0 +1,180 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { mergeTranslationArtifacts } from "./merge-translation-artifacts.mjs";
+
+test("merges language outputs and creates one combined sync entry", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "translation-merge-"));
+  t.after(() => fs.rm(root, { recursive: true, force: true }));
+
+  const artifactsRoot = path.join(root, "artifacts");
+  const websiteRoot = path.join(root, "website");
+  const languages = ["zh", "de"];
+  const shardCount = 2;
+  const commit = "abc123";
+
+  await fs.mkdir(websiteRoot, { recursive: true });
+  await fs.writeFile(
+    path.join(websiteRoot, "translation-changelog.json"),
+    "[]\n",
+  );
+  for (const language of languages) {
+    await fs.mkdir(path.join(websiteRoot, "content", language), {
+      recursive: true,
+    });
+    await fs.writeFile(
+      path.join(websiteRoot, "content", language, "old.md"),
+      "stale translation\n",
+    );
+  }
+
+  for (const [languageIndex, language] of languages.entries()) {
+    for (let shardIndex = 0; shardIndex < shardCount; shardIndex++) {
+      const artifactRoot = path.join(
+        artifactsRoot,
+        `translation-${language}-${shardIndex}`,
+      );
+      const file = `guide-${shardIndex}.md`;
+      const timestamp = `2026-07-13T00:00:0${languageIndex + shardIndex}Z`;
+      await fs.mkdir(path.join(artifactRoot, "content", language), {
+        recursive: true,
+      });
+      await fs.writeFile(
+        path.join(artifactRoot, "content", language, file),
+        `${language} shard ${shardIndex}\n`,
+      );
+      await fs.writeFile(
+        path.join(artifactRoot, "last-sync.json"),
+        `${JSON.stringify({ commit, timestamp, files: [] })}\n`,
+      );
+      await fs.writeFile(
+        path.join(artifactRoot, "translation-changelog.json"),
+        `${JSON.stringify([
+          {
+            timestamp,
+            commit,
+            sourceLanguage: "en",
+            translatedFiles: {
+              [language]: { success: [file], failed: [] },
+            },
+            stats: {
+              totalFiles: 2,
+              languages: 1,
+              successCount: 1,
+              failedCount: 0,
+            },
+            shard: { index: shardIndex, count: shardCount },
+            deletedFiles: ["old.md"],
+          },
+        ])}\n`,
+      );
+    }
+  }
+
+  await mergeTranslationArtifacts(
+    artifactsRoot,
+    websiteRoot,
+    languages,
+    shardCount,
+  );
+
+  const changelog = JSON.parse(
+    await fs.readFile(
+      path.join(websiteRoot, "translation-changelog.json"),
+      "utf8",
+    ),
+  );
+  const syncRecord = JSON.parse(
+    await fs.readFile(path.join(websiteRoot, "last-sync.json"), "utf8"),
+  );
+
+  assert.deepEqual(Object.keys(changelog[0].translatedFiles), languages);
+  assert.deepEqual(changelog[0].stats, {
+    totalFiles: 2,
+    languages: 2,
+    successCount: 4,
+    failedCount: 0,
+  });
+  assert.equal(syncRecord.timestamp, "2026-07-13T00:00:02Z");
+  assert.equal(
+    await fs.readFile(
+      path.join(websiteRoot, "content", "zh", "guide-1.md"),
+      "utf8",
+    ),
+    "zh shard 1\n",
+  );
+  await assert.rejects(
+    fs.access(path.join(websiteRoot, "content", "zh", "old.md")),
+    { code: "ENOENT" },
+  );
+});
+
+test("rejects artifacts that target different commits", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "translation-merge-"));
+  t.after(() => fs.rm(root, { recursive: true, force: true }));
+
+  const artifactsRoot = path.join(root, "artifacts");
+  const websiteRoot = path.join(root, "website");
+  const languages = ["zh", "de"];
+  const shardCount = 2;
+  await fs.mkdir(websiteRoot, { recursive: true });
+  await fs.writeFile(
+    path.join(websiteRoot, "translation-changelog.json"),
+    "[]\n",
+  );
+
+  for (const language of languages) {
+    for (let shardIndex = 0; shardIndex < shardCount; shardIndex++) {
+      const artifactRoot = path.join(
+        artifactsRoot,
+        `translation-${language}-${shardIndex}`,
+      );
+      const commit = language === "zh" ? "commit-a" : "commit-b";
+      await fs.mkdir(path.join(artifactRoot, "content", language), {
+        recursive: true,
+      });
+      await fs.writeFile(
+        path.join(artifactRoot, "last-sync.json"),
+        JSON.stringify({
+          commit,
+          timestamp: "2026-07-13T00:00:00Z",
+          files: [],
+        }),
+      );
+      await fs.writeFile(
+        path.join(artifactRoot, "translation-changelog.json"),
+        JSON.stringify([
+          {
+            timestamp: "2026-07-13T00:00:00Z",
+            commit,
+            sourceLanguage: "en",
+            translatedFiles: {
+              [language]: { success: [], failed: [] },
+            },
+            stats: {
+              totalFiles: 0,
+              languages: 1,
+              successCount: 0,
+              failedCount: 0,
+            },
+            shard: { index: shardIndex, count: shardCount },
+            deletedFiles: [],
+          },
+        ]),
+      );
+    }
+  }
+
+  await assert.rejects(
+    mergeTranslationArtifacts(
+      artifactsRoot,
+      websiteRoot,
+      languages,
+      shardCount,
+    ),
+    /different commits/,
+  );
+});

--- a/.github/scripts/sync-helpers.test.cjs
+++ b/.github/scripts/sync-helpers.test.cjs
@@ -1,0 +1,38 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const {
+  parseDeletedDocFiles,
+  partitionFilesByWeight,
+} = require("../../translator/dist/sync.js");
+
+test("treats deletions and rename sources as removed documents", () => {
+  const status = [
+    "D\tdocs/removed.md",
+    "R100\tdocs/old-name.md\tdocs/new-name.md",
+    "M\tdocs/changed.md",
+    "D\tpackages/not-docs.md",
+    "D\tdocs/image.png",
+  ].join("\n");
+
+  assert.deepEqual(parseDeletedDocFiles(status, "docs"), [
+    "docs/removed.md",
+    "docs/old-name.md",
+  ]);
+});
+
+test("balances large files deterministically across shards", () => {
+  const weighted = [
+    { file: "small-b.md", size: 1 },
+    { file: "large.md", size: 10 },
+    { file: "medium.md", size: 6 },
+    { file: "small-a.md", size: 1 },
+  ];
+
+  const shards = partitionFilesByWeight(weighted, 2);
+
+  assert.deepEqual(shards, [
+    { size: 10, files: ["large.md"] },
+    { size: 8, files: ["medium.md", "small-a.md", "small-b.md"] },
+  ]);
+});

--- a/.github/workflows/daily-translate.yml
+++ b/.github/workflows/daily-translate.yml
@@ -1,46 +1,69 @@
 name: Daily Incremental Translation
 
-# Runs the translator's incremental `sync` once a day, then (if anything
-# changed) commits the new translations to main, rebuilds the site and
-# deploys it — all in one job.
-#
-# Prerequisites (set in repo Settings → Secrets and variables → Actions):
-#   - Secret  TRANSLATE_CODING_PLAN_API_KEY : a cloud-reachable model API key
-#   Model / base URL are set as plain env below; change them if you switch
-#   providers. The incremental baseline lives in website/last-sync.json
-#   (tracked in git), so each run only translates what changed upstream.
-#
-# Note: this job pushes to main with GITHUB_TOKEN, which by design does NOT
-# trigger other workflows (e.g. deploy-docs.yml), so there is no double build.
-# This job therefore builds + deploys itself.
-#
-# If main is a protected branch that forbids direct pushes, either allow the
-# github-actions bot to bypass protection, or switch the push step to a PR.
+# Detect upstream changes once, translate balanced language shards in isolated
+# matrix jobs, then merge, build and publish only after every shard succeeds.
+# This keeps each unit of work safely below GitHub's six-hour per-job limit.
 
 on:
   schedule:
-    # 20:00 UTC == 04:00 Asia/Shanghai (next day). Adjust as you like.
+    # 20:00 UTC == 04:00 Asia/Shanghai (next day).
     - cron: "0 20 * * *"
   workflow_dispatch: {}
+  pull_request:
+    paths:
+      - .github/scripts/merge-translation-artifacts.mjs
+      - .github/scripts/merge-translation-artifacts.test.mjs
+      - .github/scripts/sync-helpers.test.cjs
+      - .github/workflows/daily-translate.yml
+      - translator/**
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
-  group: daily-translate
-  cancel-in-progress: false
+  group: ${{ github.event_name == 'pull_request' && format('daily-translate-pr-{0}', github.event.pull_request.number) || 'daily-translate-production' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  translate-and-deploy:
+  validate:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    # Large upstream batches can spend nearly three hours translating before
-    # the static site build starts.
-    timeout-minutes: 360
+    timeout-minutes: 15
+    steps:
+      - name: Checkout workflow commit
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Install Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Build translator
+        working-directory: ./translator
+        run: |
+          npm ci --no-audit --no-fund
+          npm run build
+
+      - name: Test translation workflow helpers
+        run: node --test .github/scripts/*.test.*
+
+  prepare:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    outputs:
+      changed: ${{ steps.detect.outputs.changed }}
+      source_commit: ${{ steps.detect.outputs.source_commit }}
+      languages: ${{ steps.detect.outputs.languages }}
+      shards: ${{ steps.detect.outputs.shards }}
+      shard_count: ${{ steps.detect.outputs.shard_count }}
     steps:
       - name: Checkout workflow ref
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.sha }}
           fetch-depth: 0
 
       - name: Install Node.js
@@ -48,75 +71,168 @@ jobs:
         with:
           node-version: 22
 
-      - name: Build translator (dist is gitignored)
+      - name: Build translator
         working-directory: ./translator
         run: |
           npm ci --no-audit --no-fund
           npm run build
 
-      - name: Install website dependencies
+      - name: Detect upstream changes
+        id: detect
         working-directory: ./website
-        run: npm ci --no-audit --no-fund
+        env:
+          FORCE_COLOR: "0"
+          SHARD_COUNT: "2"
+        run: |
+          set -o pipefail
+          node ../translator/bin/qwen-translator sync \
+            --detect-only \
+            --result-file /tmp/detect-result.json
+          echo "source_commit=$(git -C .temp-source-repo rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "languages=$(node -p 'JSON.stringify(require("./translation.config.json").targetLanguages)')" >> "$GITHUB_OUTPUT"
+          echo "shards=$(node -p 'JSON.stringify(Array.from({ length: Number(process.env.SHARD_COUNT) }, (_, index) => index))')" >> "$GITHUB_OUTPUT"
+          echo "shard_count=$SHARD_COUNT" >> "$GITHUB_OUTPUT"
+          if [ "$(node -p "require('/tmp/detect-result.json').changes")" -eq 0 ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No upstream doc changes today."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Upstream changes detected; starting language jobs."
+          fi
 
-      - name: Run incremental translation sync
+  translate:
+    needs: prepare
+    if: needs.prepare.outputs.changed == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    strategy:
+      fail-fast: false
+      # Keep the API load at the previously hardened concurrency of three,
+      # while giving every language shard its own six-hour job budget.
+      max-parallel: 3
+      matrix:
+        language: ${{ fromJSON(needs.prepare.outputs.languages) }}
+        shard: ${{ fromJSON(needs.prepare.outputs.shards) }}
+    steps:
+      - name: Checkout workflow ref
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+
+      - name: Install Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Build translator
+        working-directory: ./translator
+        run: |
+          npm ci --no-audit --no-fund
+          npm run build
+
+      - name: Translate ${{ matrix.language }} (shard ${{ matrix.shard }})
         working-directory: ./website
         env:
           OPENAI_API_KEY: ${{ secrets.TRANSLATE_CODING_PLAN_API_KEY }}
           OPENAI_BASE_URL: https://coding.dashscope.aliyuncs.com/v1
           QWEN_MODEL: qwen3.7-plus
-          # Keep each response moderate; larger docs auto-chunk from this cap.
           QWEN_MAX_TOKENS: "32768"
-          # The MaaS compatible endpoint can close long responses when all
-          # target languages run at once. Keep CI conservative and let API
-          # retries handle transient disconnects.
-          QWEN_TRANSLATION_CONCURRENCY: "3"
           QWEN_API_MAX_RETRIES: "6"
           QWEN_CHUNK_CHARS: "12000"
+          FORCE_COLOR: "0"
         run: |
           set -o pipefail
-          node ../translator/bin/qwen-translator sync 2>&1 | tee /tmp/sync.log
-          # Fail the run if any file failed to translate, so we never commit a
-          # baseline that skips broken files (sync advances last-sync.json even
-          # on per-file failures). A failed run leaves main untouched and the
-          # next run retries from the same baseline.
-          if grep -qE '翻译完成: [0-9]+ 成功, [1-9][0-9]* 失败' /tmp/sync.log; then
-            echo "::error::Some files failed to translate; not committing."
-            exit 1
-          fi
+          node ../translator/bin/qwen-translator sync \
+            --language "${{ matrix.language }}" \
+            --source-commit "${{ needs.prepare.outputs.source_commit }}" \
+            --shard-index "${{ matrix.shard }}" \
+            --shard-count "${{ needs.prepare.outputs.shard_count }}"
 
-      - name: Detect changes
-        id: detect
+      - name: Stage ${{ matrix.language }} shard ${{ matrix.shard }} result
+        working-directory: ./website
+        env:
+          LANGUAGE: ${{ matrix.language }}
         run: |
-          if [ -n "$(git status --porcelain website/content website/last-sync.json website/translation-changelog.json)" ]; then
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-            if [ "$GITHUB_REF_NAME" = "main" ]; then
-              echo "Changes detected — will build, commit and deploy."
-            else
-              echo "Changes detected — will build only because this run is on $GITHUB_REF_NAME."
-            fi
-          else
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-            echo "No upstream doc changes today — nothing to do."
-          fi
+          mkdir -p translation-output
+          while IFS= read -r -d '' file; do
+            mkdir -p "translation-output/$(dirname "$file")"
+            cp "$file" "translation-output/$file"
+          done < <(git ls-files -z --modified --others --exclude-standard -- "content/$LANGUAGE")
+          cp last-sync.json translation-changelog.json translation-output/
+
+      - name: Upload ${{ matrix.language }} shard ${{ matrix.shard }} result
+        uses: actions/upload-artifact@v7
+        with:
+          name: translation-${{ matrix.language }}-${{ matrix.shard }}
+          if-no-files-found: error
+          retention-days: 2
+          path: website/translation-output
+
+  finalize:
+    needs: [prepare, translate]
+    if: needs.prepare.outputs.changed == 'true' && needs.translate.result == 'success'
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - name: Checkout workflow ref
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+
+      - name: Install Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Build translator
+        working-directory: ./translator
+        run: |
+          npm ci --no-audit --no-fund
+          npm run build
+
+      - name: Update source-language documents
+        working-directory: ./website
+        run: >-
+          node ../translator/bin/qwen-translator sync --source-only
+          --source-commit "${{ needs.prepare.outputs.source_commit }}"
+
+      - name: Download translation results
+        uses: actions/download-artifact@v8
+        with:
+          pattern: translation-*
+          path: .translation-artifacts
+
+      - name: Merge translation results
+        run: >-
+          node .github/scripts/merge-translation-artifacts.mjs
+          .translation-artifacts website "${{ needs.prepare.outputs.shard_count }}"
+
+      - name: Install website dependencies
+        working-directory: ./website
+        run: npm ci --no-audit --no-fund
 
       - name: Build website
-        if: steps.detect.outputs.changed == 'true'
         working-directory: ./website
         env:
           NODE_OPTIONS: --max-old-space-size=12288
         run: npm run build
 
       - name: Commit translations to main
-        if: steps.detect.outputs.changed == 'true' && github.ref_name == 'main'
+        if: github.ref_name == 'main'
         run: |
           git config user.name "qwen-docs-bot"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add website/content website/last-sync.json website/translation-changelog.json
           git commit -m "docs(i18n): daily incremental translation sync [skip ci]"
+          git pull --rebase origin main
           git push origin HEAD:main
 
       - name: Deploy to GitHub Pages
-        if: steps.detect.outputs.changed == 'true' && github.ref_name == 'main'
+        if: github.ref_name == 'main'
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/translator/src/cli.ts
+++ b/translator/src/cli.ts
@@ -341,7 +341,12 @@ class TranslationCLI {
   async syncDocuments(
     force: boolean = false,
     detectOnly: boolean = false,
-    sourceOnly: boolean = false
+    sourceOnly: boolean = false,
+    targetLanguage?: string,
+    sourceCommit?: string,
+    shardIndex?: number,
+    shardCount?: number,
+    resultFile?: string
   ): Promise<void> {
     const projectConfig = await this.loadProjectConfig();
     if (!projectConfig) {
@@ -355,14 +360,30 @@ class TranslationCLI {
 
     console.log(chalk.blue("🔄 Starting document synchronization..."));
 
+    if (
+      targetLanguage &&
+      !projectConfig.targetLanguages.includes(targetLanguage)
+    ) {
+      throw new Error(
+        `Unsupported target language: ${targetLanguage}. Configured languages: ${projectConfig.targetLanguages.join(
+          ", "
+        )}`
+      );
+    }
+
     const syncManager = new SyncManager({
       sourceRepo: projectConfig.sourceRepo,
       docsPath: projectConfig.docsPath,
       sourceLanguage: projectConfig.sourceLanguage, // 传递源语言
       projectRoot: process.cwd(), // 传递项目根目录
-      targetLanguages: projectConfig.targetLanguages, // 传递目标语言
+      targetLanguages: targetLanguage
+        ? [targetLanguage]
+        : projectConfig.targetLanguages, // 传递目标语言
       outputDir: projectConfig.outputDir, // 传递输出目录
       branch: projectConfig.branch, // 传递分支参数
+      sourceCommit,
+      shardIndex,
+      shardCount,
       excludeFromTranslation: projectConfig.excludeFromTranslation, // 传递排除翻译列表
     });
 
@@ -371,6 +392,12 @@ class TranslationCLI {
         detectOnly,
         sourceOnly,
       });
+
+      if (resultFile) {
+        const outputPath = path.resolve(resultFile);
+        await fs.ensureDir(path.dirname(outputPath));
+        await fs.writeJson(outputPath, result, { spaces: 2 });
+      }
 
       if (result.success) {
         console.log(
@@ -744,11 +771,31 @@ async function main() {
       "-s, --source-only",
       "Detect changes and write source-language docs, but skip translation; does not advance last-sync.json (no API key required)"
     )
+    .option(
+      "-l, --language <lang>",
+      "Translate only one configured target language"
+    )
+    .option(
+      "--source-commit <sha>",
+      "Pin synchronization to a specific source repository commit"
+    )
+    .option("--shard-index <index>", "Zero-based translation shard index")
+    .option("--shard-count <count>", "Total number of translation shards")
+    .option("--result-file <path>", "Write the structured sync result as JSON")
     .action(async (options) => {
       await cli.syncDocuments(
         options.force,
         options.detectOnly,
-        options.sourceOnly
+        options.sourceOnly,
+        options.language,
+        options.sourceCommit,
+        options.shardIndex === undefined
+          ? undefined
+          : Number(options.shardIndex),
+        options.shardCount === undefined
+          ? undefined
+          : Number(options.shardCount),
+        options.resultFile
       );
     });
 

--- a/translator/src/sync.ts
+++ b/translator/src/sync.ts
@@ -12,6 +12,46 @@ function isMetaFile(filePath: string): boolean {
   return /^_meta\.(ts|tsx|js|jsx|mjs|cjs|json)$/.test(path.basename(filePath));
 }
 
+export function parseDeletedDocFiles(
+  nameStatus: string,
+  docsPath: string
+): string[] {
+  return nameStatus
+    ? nameStatus
+        .trim()
+        .split("\n")
+        .flatMap((line) => {
+          const [status, firstPath] = line.split("\t");
+          return status === "D" || status.startsWith("R") ? [firstPath] : [];
+        })
+        .filter(
+          (file) => file.endsWith(".md") && file.startsWith(`${docsPath}/`)
+        )
+    : [];
+}
+
+export function partitionFilesByWeight(
+  weightedFiles: { file: string; size: number }[],
+  shardCount: number
+): { size: number; files: string[] }[] {
+  const shards = Array.from({ length: shardCount }, () => ({
+    size: 0,
+    files: [] as string[],
+  }));
+  const sorted = [...weightedFiles].sort(
+    (a, b) => b.size - a.size || a.file.localeCompare(b.file)
+  );
+
+  for (const item of sorted) {
+    const target = shards.reduce((smallest, shard) =>
+      shard.size < smallest.size ? shard : smallest
+    );
+    target.files.push(item.file);
+    target.size += item.size;
+  }
+  return shards;
+}
+
 /**
  * 版本同步管理器
  * 检测原仓库文档变更，自动同步和翻译更新
@@ -27,6 +67,9 @@ interface SyncOptions {
   projectRoot?: string; // 项目根目录
   outputDir?: string; // 输出目录
   branch?: string; // 新增：源仓库分支
+  sourceCommit?: string; // 可选：固定本次同步的源仓库提交
+  shardIndex?: number; // 可选：本次只翻译指定分片（从 0 开始）
+  shardCount?: number; // 可选：翻译分片总数
   // 新增：跳过翻译的路径（目录前缀或精确文件名，相对 docsPath）。
   // 这些文档仍会同步到 content/<sourceLanguage>，但不会翻译到目标语言。
   excludeFromTranslation?: string[];
@@ -40,6 +83,7 @@ interface SyncRecord {
 
 interface ChangeDetectionResult {
   files: string[];
+  deletedFiles: string[];
   latestCommit: string;
   isFirstSync: boolean;
 }
@@ -48,6 +92,7 @@ interface TranslationResult {
   success: number;
   failed: number;
   files: string[];
+  failedFiles: string[];
 }
 
 interface TranslationChangelogEntry {
@@ -66,6 +111,11 @@ interface TranslationChangelogEntry {
     successCount: number;
     failedCount: number;
   };
+  shard?: {
+    index: number;
+    count: number;
+  };
+  deletedFiles?: string[];
 }
 
 interface SyncResult {
@@ -83,6 +133,9 @@ export class SyncManager {
   private sourceLanguage: string; // 新增：源文档语言
   private targetLanguages: string[];
   private branch: string; // 新增：源仓库分支
+  private sourceCommit?: string;
+  private shardIndex: number;
+  private shardCount: number;
   private lastSyncFile: string;
   private changelogFile: string;
   private translator: DocumentTranslator | null = null; // 懒加载：仅在需要翻译时构造
@@ -117,6 +170,26 @@ export class SyncManager {
       "es",
     ];
     this.branch = options.branch || "main"; // 默认使用 main 分支
+    this.sourceCommit = options.sourceCommit;
+    if (
+      this.sourceCommit &&
+      !/^[0-9a-f]{40}$/i.test(this.sourceCommit)
+    ) {
+      throw new Error(`无效的源仓库提交: ${this.sourceCommit}`);
+    }
+    this.shardIndex = options.shardIndex ?? 0;
+    this.shardCount = options.shardCount ?? 1;
+    if (
+      !Number.isInteger(this.shardIndex) ||
+      !Number.isInteger(this.shardCount) ||
+      this.shardCount < 1 ||
+      this.shardIndex < 0 ||
+      this.shardIndex >= this.shardCount
+    ) {
+      throw new Error(
+        `无效的翻译分片: ${this.shardIndex}/${this.shardCount}`
+      );
+    }
     this.excludeFromTranslation = options.excludeFromTranslation || [];
 
     // 设置输出目录
@@ -218,7 +291,7 @@ export class SyncManager {
       // 刻意不推进同步基线：目标语言译文此时会落后于源文档，待配置 key 后再次运行
       // sync 即可补齐翻译（届时仍会检测到这些文件，可自愈）。
       if (options.sourceOnly) {
-        await this.updateBaseDocs();
+        await this.updateBaseDocs(changes.deletedFiles);
         console.log(
           chalk.green(
             "✅ 已更新源文档（source-only：未翻译；未推进 last-sync.json，配置 key 后再次 sync 可补齐翻译）"
@@ -241,18 +314,32 @@ export class SyncManager {
       this.getTranslator();
 
       // 更新基础文档
-      await this.updateBaseDocs();
+      await this.updateBaseDocs(changes.deletedFiles);
+
+      const shardFiles = await this.selectTranslationShard(changes.files);
 
       // 翻译更新的文件
       const translationResults = await this.translateChangedFiles(
-        changes.files
+        shardFiles
       );
+
+      const failedCount = Object.values(translationResults).reduce(
+        (total, result) => total + result.failed,
+        0
+      );
+      if (failedCount > 0) {
+        throw new Error(
+          `${failedCount} 个文件翻译失败，未推进同步基线`
+        );
+      }
 
       // 记录翻译日志
       await this.saveTranslationChangelog(
         changes.latestCommit,
         changes.files,
-        translationResults
+        translationResults,
+        { index: this.shardIndex, count: this.shardCount },
+        changes.deletedFiles
       );
 
       // 更新同步记录
@@ -297,6 +384,15 @@ export class SyncManager {
         );
       }
 
+      // Matrix jobs may start hours apart. Pin every job to the commit found
+      // by the prepare job so their artifacts always describe one snapshot.
+      if (this.sourceCommit) {
+        execSync(
+          `cd ${tempDir} && git fetch origin ${this.sourceCommit} && git checkout --detach ${this.sourceCommit}`,
+          { stdio: "pipe" }
+        );
+      }
+
       // 获取最新提交
       const latestCommit = execSync(`cd ${tempDir} && git rev-parse HEAD`, {
         encoding: "utf8",
@@ -310,6 +406,7 @@ export class SyncManager {
         const allFiles = await this.getAllDocFiles(tempDir);
         return {
           files: allFiles,
+          deletedFiles: [],
           latestCommit,
           isFirstSync: true,
         };
@@ -331,8 +428,15 @@ export class SyncManager {
             )
         : [];
 
+      const nameStatus = execSync(
+        `cd ${tempDir} && git diff --name-status ${lastSync.commit} HEAD -- ${this.docsPath}/`,
+        { encoding: "utf8" }
+      ).trim();
+      const deletedFiles = parseDeletedDocFiles(nameStatus, this.docsPath);
+
       return {
         files,
+        deletedFiles,
         latestCommit,
         isFirstSync: false,
       };
@@ -418,7 +522,7 @@ export class SyncManager {
   /**
    * 更新基础文档
    */
-  async updateBaseDocs(): Promise<void> {
+  async updateBaseDocs(deletedFiles: string[] = []): Promise<void> {
     // 使用项目根目录下的临时目录
     const tempDir = path.join(this.projectRoot, ".temp-source-repo");
     const sourceDocsDir = path.join(tempDir, this.docsPath);
@@ -430,6 +534,13 @@ export class SyncManager {
     );
 
     console.log(chalk.blue("📂 更新基础文档..."));
+
+    for (const file of deletedFiles) {
+      const relativePath = file.replace(`${this.docsPath}/`, "");
+      await fs.remove(path.join(sourceDocsTargetDir, relativePath));
+      await fs.remove(path.join(contentSourceDir, relativePath));
+      console.log(chalk.gray(`  → 删除上游文档: ${relativePath}`));
+    }
 
     // 1. 复制到 .source-docs 目录
     await fs.ensureDir(sourceDocsTargetDir);
@@ -483,6 +594,49 @@ export class SyncManager {
     });
   }
 
+  /**
+   * 将需翻译的文档按源文件字节数做贪心均衡分片。
+   * 所有 job 面对同一 source commit，因此会得到完全相同的分片结果。
+   */
+  private async selectTranslationShard(
+    changedFiles: string[]
+  ): Promise<string[]> {
+    if (this.shardCount === 1) {
+      return changedFiles;
+    }
+
+    const tempDir = path.join(this.projectRoot, ".temp-source-repo");
+    const weightedFiles: { file: string; size: number }[] = [];
+
+    for (const file of changedFiles) {
+      const relativePath = file.replace(`${this.docsPath}/`, "");
+      if (
+        isMetaFile(relativePath) ||
+        this.isExcludedFromTranslation(relativePath)
+      ) {
+        continue;
+      }
+
+      const sourcePath = path.join(tempDir, file);
+      if (!(await fs.pathExists(sourcePath))) {
+        continue;
+      }
+      const stat = await fs.stat(sourcePath);
+      weightedFiles.push({ file, size: stat.size });
+    }
+
+    const shards = partitionFilesByWeight(weightedFiles, this.shardCount);
+
+    const selected = new Set(shards[this.shardIndex].files);
+    const files = changedFiles.filter((file) => selected.has(file));
+    console.log(
+      chalk.blue(
+        `🧩 翻译分片 ${this.shardIndex + 1}/${this.shardCount}: ${files.length} 个文件, ${shards[this.shardIndex].size} 字节`
+      )
+    );
+    return files;
+  }
+
   async translateChangedFiles(
     changedFiles: string[]
   ): Promise<Record<string, TranslationResult>> {
@@ -507,6 +661,7 @@ export class SyncManager {
         success: 0,
         failed: 0,
         files: [],
+        failedFiles: [],
       };
 
       console.log(chalk.blue(`🚀 启动 ${language} 翻译任务`));
@@ -571,6 +726,7 @@ export class SyncManager {
             chalk.red(`❌ ${language}: ${file} - ${error.message}`)
           );
           result.failed++;
+          result.failedFiles.push(file.replace(`${this.docsPath}/`, ""));
         }
       }
 
@@ -628,7 +784,9 @@ export class SyncManager {
   async saveTranslationChangelog(
     commitHash: string,
     changedFiles: string[],
-    translationResults: Record<string, TranslationResult>
+    translationResults: Record<string, TranslationResult>,
+    shard: { index: number; count: number } = { index: 0, count: 1 },
+    deletedFiles: string[] = []
   ): Promise<void> {
     const entry: TranslationChangelogEntry = {
       timestamp: new Date().toISOString(),
@@ -641,13 +799,17 @@ export class SyncManager {
         successCount: 0,
         failedCount: 0,
       },
+      shard,
+      deletedFiles: deletedFiles.map((file) =>
+        file.replace(`${this.docsPath}/`, "")
+      ),
     };
 
     // 整理翻译结果
     for (const [language, result] of Object.entries(translationResults)) {
       entry.translatedFiles[language] = {
         success: result.files,
-        failed: [], // 可以从 result 中提取失败的文件
+        failed: result.failedFiles,
       };
       entry.stats.successCount += result.success;
       entry.stats.failedCount += result.failed;


### PR DESCRIPTION
## Summary

- split each target language into two weight-balanced shards, with at most three translation jobs running concurrently
- pin detection, translation, and finalization to one workflow and upstream source commit
- merge structured artifacts only after validating shard metadata, commit consistency, statistics, failures, and deletion lists
- propagate upstream deletions and rename sources to every language without advancing the baseline after a failed translation
- add pull-request validation with read-only permissions and isolate PR concurrency from production runs

## Root cause

The scheduled workflow translated all six languages in one job and committed only after every translation completed. Recent runs reached GitHub Actions six-hour per-job limit while translation was still progressing. The timed-out runs never advanced `last-sync.json`, so each following run repeated the growing backlog.

Language-only parallelism was still too close to the limit for the current backlog. The workflow now creates twelve language-by-shard jobs. Source byte size is used to balance each pair of shards while `max-parallel: 3` preserves the existing API load ceiling.

## Reliability details

- newly created translation files are included in artifacts
- any per-file failure fails the job before changelog or baseline updates
- upstream deletions and rename sources remove stale source and translated files
- the final merger rejects missing or inconsistent artifacts before commit
- only the final publish job receives `contents: write`; PR validation is read-only
- a late main update is rebased before the bot pushes

## Validation

- translator TypeScript build
- 4 Node tests covering shard merge, cross-commit rejection, delete/rename parsing, and deterministic balancing
- Actionlint validation of the workflow
- structured real upstream `sync --detect-only` run (75 changed documents)
- invalid shard argument failure check
- `git diff --check`
- full website production build: 1652 static routes generated and 1632 pages indexed

The real model API path requires the repository secret and can be exercised by manually dispatching the workflow after merge.