### PR TITLE
fix: 添加 .npmrc 使用公网 npm registry 修复 CI 构建

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/

--- a/website/.npmrc
+++ b/website/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/


### PR DESCRIPTION
## 问题

PR #153 合并后 CI 构建失败，原因是 GitHub Actions runner 无法访问阿里内网 npm registry（`registry.anpm.alibaba-inc.com`）。

## 修复

在根目录和 `website/` 子目录各添加 `.npmrc` 文件，指定使用公网 npm registry（`https://registry.npmjs.org/`），确保 CI 环境能正常安装依赖。