### PR TITLE
fix(translator): report failed batch files

### DIFF
--- a/translator/package.json
+++ b/translator/package.json
@@ -18,7 +18,7 @@
     "build": "rm -rf dist && tsc",
     "clear": "rm -rf dist",
     "dev": "npm run clear && tsc --watch",
-    "test": "jest"
+    "test": "tsx --test src/**/*.test.ts"
   },
   "keywords": [
     "qwen",

--- a/translator/src/sync.test.ts
+++ b/translator/src/sync.test.ts
@@ -1,0 +1,37 @@
+import fs from "fs-extra";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { describe, it } from "node:test";
+import { SyncManager } from "./sync";
+
+describe("SyncManager translation changelog", () => {
+  it("records failed filenames for each language", async () => {
+    const projectRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), "qwen-sync-test-")
+    );
+    const manager = new SyncManager({
+      projectRoot,
+      targetLanguages: ["de"],
+    });
+
+    try {
+      await manager.saveTranslationChangelog("abc123", ["docs/guide.md"], {
+        de: {
+          success: 0,
+          failed: 1,
+          files: [],
+          failedFiles: ["guide.md"],
+        },
+      });
+
+      const changelog = await fs.readJson(
+        path.join(projectRoot, "translation-changelog.json")
+      );
+
+      assert.deepEqual(changelog[0].translatedFiles.de.failed, ["guide.md"]);
+    } finally {
+      await fs.remove(projectRoot);
+    }
+  });
+});

--- a/translator/src/sync.ts
+++ b/translator/src/sync.ts
@@ -2,7 +2,7 @@ import fs from "fs-extra";
 import path from "path";
 import { execSync } from "child_process";
 import chalk from "chalk";
-import { DocumentTranslator } from "./translator";
+import { DocumentTranslator, TranslationBatchError } from "./translator";
 
 /**
  * 判断是否为 Nextra 导航文件（_meta.ts/js/json 等）。
@@ -48,6 +48,7 @@ interface TranslationResult {
   success: number;
   failed: number;
   files: string[];
+  failedFiles: string[];
 }
 
 interface TranslationChangelogEntry {
@@ -254,6 +255,14 @@ export class SyncManager {
         changes.files,
         translationResults
       );
+
+      const failedFiles = Object.entries(translationResults).flatMap(
+        ([language, result]) =>
+          result.failedFiles.map((file) => `${language}:${file}`)
+      );
+      if (failedFiles.length > 0) {
+        throw new TranslationBatchError(failedFiles);
+      }
 
       // 更新同步记录
       await this.updateSyncRecord(changes.latestCommit);
@@ -507,6 +516,7 @@ export class SyncManager {
         success: 0,
         failed: 0,
         files: [],
+        failedFiles: [],
       };
 
       console.log(chalk.blue(`🚀 启动 ${language} 翻译任务`));
@@ -571,6 +581,7 @@ export class SyncManager {
             chalk.red(`❌ ${language}: ${file} - ${error.message}`)
           );
           result.failed++;
+          result.failedFiles.push(file.replace(`${this.docsPath}/`, ""));
         }
       }
 
@@ -647,7 +658,7 @@ export class SyncManager {
     for (const [language, result] of Object.entries(translationResults)) {
       entry.translatedFiles[language] = {
         success: result.files,
-        failed: [], // 可以从 result 中提取失败的文件
+        failed: result.failedFiles,
       };
       entry.stats.successCount += result.success;
       entry.stats.failedCount += result.failed;

--- a/translator/src/translator.test.ts
+++ b/translator/src/translator.test.ts
@@ -1,0 +1,62 @@
+import fs from "fs-extra";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { describe, it } from "node:test";
+import { DocumentTranslator } from "./translator";
+
+class RecordingTranslator extends DocumentTranslator {
+  constructor(projectRoot: string) {
+    super({ projectRoot });
+  }
+
+  override async translateDocument(
+    filePath: string,
+    targetLang: string
+  ): Promise<string> {
+    if (path.basename(filePath) === "broken.md") {
+      throw new Error("translation unavailable");
+    }
+
+    return `${targetLang}:${await fs.readFile(filePath, "utf8")}`;
+  }
+}
+
+describe("DocumentTranslator.translateDirectory", () => {
+  it("rejects with the failed filenames after preserving successful output", async () => {
+    const projectRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), "qwen-translator-test-")
+    );
+    const sourceDir = path.join(projectRoot, "source");
+    const targetDir = path.join(projectRoot, "target");
+    await fs.outputFile(path.join(sourceDir, "working.md"), "working");
+    await fs.outputFile(path.join(sourceDir, "broken.md"), "broken");
+
+    const previousApiKey = process.env.OPENAI_API_KEY;
+    process.env.OPENAI_API_KEY = "test-key";
+
+    try {
+      const translator = new RecordingTranslator(projectRoot);
+
+      await assert.rejects(
+        translator.translateDirectory(sourceDir, targetDir, "de"),
+        (error: unknown) => {
+          assert.match(String(error), /broken\.md/);
+          return true;
+        }
+      );
+      assert.equal(
+        await fs.readFile(path.join(targetDir, "working.md"), "utf8"),
+        "de:working"
+      );
+      assert.equal(await fs.pathExists(path.join(targetDir, "broken.md")), false);
+    } finally {
+      if (previousApiKey === undefined) {
+        delete process.env.OPENAI_API_KEY;
+      } else {
+        process.env.OPENAI_API_KEY = previousApiKey;
+      }
+      await fs.remove(projectRoot);
+    }
+  });
+});

--- a/translator/src/translator.ts
+++ b/translator/src/translator.ts
@@ -24,6 +24,17 @@ interface TranslationOptions {
   projectRoot?: string;
 }
 
+/** Reports every document that failed during a directory translation. */
+export class TranslationBatchError extends Error {
+  readonly failedFiles: readonly string[];
+
+  constructor(failedFiles: readonly string[]) {
+    super(`Failed to translate: ${failedFiles.join(", ")}`);
+    this.name = "TranslationBatchError";
+    this.failedFiles = failedFiles;
+  }
+}
+
 export class DocumentTranslator {
   private openai: OpenAI;
   private apiConfig: TranslatorConfig;
@@ -482,6 +493,7 @@ ${content}`;
     );
 
     console.log(chalk.blue(`📁 Found ${markdownFiles.length} Markdown files`));
+    const failedFiles: string[] = [];
 
     for (const file of markdownFiles) {
       // Ensure file is string type
@@ -500,10 +512,15 @@ ${content}`;
         await fs.writeFile(targetPath, translatedContent, "utf-8");
         console.log(chalk.green(`✓ Saved: ${path.basename(targetPath)}`));
       } catch (error: any) {
+        failedFiles.push(fileName);
         console.error(
           chalk.red(`✗ Failed to translate ${file}: ${error.message}`)
         );
       }
+    }
+
+    if (failedFiles.length > 0) {
+      throw new TranslationBatchError(failedFiles);
     }
   }
 }


### PR DESCRIPTION
## Problem

Per-file translation failures are counted but omitted from `translation-changelog.json`. The standalone `markdown` command also completes successfully after producing partial output, and sync can advance its baseline despite failed translations.

## Changes

- record failed filenames for each target language in the changelog
- reject directory translation after preserving successful outputs
- stop sync before updating `last-sync.json` when any translation fails
- run translator tests with the existing `tsx` dependency and add regression coverage for both paths

## Validation

- `cd translator && npm test`
- `cd translator && npm run build`
- autoreview against `origin/main`: clean

## Scope

Successful translations are still written as they complete. This PR changes failure reporting and exit behavior only; it does not add rollback of successful files.