### PR TITLE
fix: restore as any cast in layout.tsx for pageMap type compatibility

### DIFF
--- a/website/app/[lang]/layout.tsx
+++ b/website/app/[lang]/layout.tsx
@@ -31,7 +31,7 @@ const LanguageLayout: FC<LayoutProps> = async ({ children, params }) => {
   }
 
   let sourcePageMap = await getPageMap(`/${lang}`);
-  sourcePageMap = modifyUpdatesSidebar(sourcePageMap, lang);
+  sourcePageMap = modifyUpdatesSidebar(sourcePageMap as any, lang) as any;
   //@ts-ignore
   // 用 fs 模块将 sourcePageMap 保存到本地
 


### PR DESCRIPTION
## 概述

修复 `layout.tsx` 中 `modifyUpdatesSidebar` 调用的类型兼容性问题。Nextra 的 `getPageMap` 返回类型与自定义 `PageMapItem` 接口不完全匹配，需要保留 `as any` 转换以确保编译通过。

## 变更文件

| 文件 | 说明 |
|------|------|
| `layout.tsx` | 恢复 `modifyUpdatesSidebar` 调用中的 `as any` 类型转换 |