### PR TITLE
docs(blog): analyze Resource2Skill video learning

### DIFF
--- a/website/content/en/blog/advanced/_meta.ts
+++ b/website/content/en/blog/advanced/_meta.ts
@@ -1,6 +1,11 @@
 export default {
-  index: { display: 'hidden' },
-  'qwencode-bailian-ai-marketing': 'Bailian CLI + Qwen Code for E-commerce Marketing',
-  'qwencode-mpcover-skill-guide': 'Generate Covers in One Sentence: 4 AI Cover Styles for WeChat',
-  'feat-skills-oss-styles': 'Cinematic Showcase for Your Open Source Project in One Sentence',
+  index: { display: "hidden" },
+  "qwencode-bailian-ai-marketing":
+    "Bailian CLI + Qwen Code for E-commerce Marketing",
+  "qwencode-mpcover-skill-guide":
+    "Generate Covers in One Sentence: 4 AI Cover Styles for WeChat",
+  "feat-skills-oss-styles":
+    "Cinematic Showcase for Your Open Source Project in One Sentence",
+  "resource2skill-qwencode-video-learn":
+    "From Video Tutorials to Reusable Skills: Resource2Skill and Qwen Code /learn",
 };

--- a/website/content/en/blog/advanced/resource2skill-qwencode-video-learn.mdx
+++ b/website/content/en/blog/advanced/resource2skill-qwencode-video-learn.mdx
@@ -1,0 +1,393 @@
+---
+title: "From Video Tutorials to Reusable Skills: Resource2Skill and Qwen Code /learn"
+date: "2026-07-22"
+description: "A detailed analysis of Resource2Skill and an engineering report on native video input, skill distillation, and real end-to-end validation in Qwen Code /learn"
+author: "LaZzyMan"
+tags: ["Research", "Skills", "Video", "Qwen Code", "Engineering"]
+---
+
+import { BlogPostHeader } from "@/components/blog-post-header";
+import { Callout } from "nextra/components";
+
+<BlogPostHeader
+  title="From Video Tutorials to Reusable Skills: Resource2Skill and Qwen Code /learn"
+  date="2026-07-22"
+  author="LaZzyMan"
+/>
+
+Can a software agent turn a human tutorial video into a Skill that future sessions can discover and reuse?
+
+This sounds like a video-summarization problem, but a production implementation must answer at least three separate questions: can the model receive the complete video, can it compress observations into structured and retrievable procedural knowledge, and can the generated Skill reproduce the tutorial in a real execution environment? Proving only the first question can easily turn “the API received a video” into a false claim that “the Skill works.”
+
+This article analyzes the [Resource2Skill paper](https://arxiv.org/abs/2606.29538) and its [official implementation](https://github.com/microsoft/Resource2Skill), then documents an engineering experiment that adds native video input to Qwen Code `/learn`.
+
+The main conclusions are:
+
+- Resource2Skill is not primarily about asking a vision model to watch a video. Its contribution is a closed pipeline that combines multimodal distillation, structured storage, retrieval, and deterministic acceptance gates.
+- Qwen Code already has a filesystem Skill format, main-agent file tools, OpenAI-compatible video conversion, and model modality declarations. `/learn` is therefore a natural entry point for native video.
+- The implementation successfully completed the real chain from a full local video to a two-file Skill, fresh-session discovery and invocation, and a rendered browser artifact.
+- Final fidelity to the official tutorial still failed. The sliced-text motion was correct, but the sweeping line used the wrong containing block.
+- The next step should be deterministic schema, provenance, structural-execution, and render gates—not more prompt tuning.
+
+## 1. The problem Resource2Skill addresses
+
+Most Skill libraries are written by experts, mined from agent trajectories, or extracted from text and code. This leaves out one of the main ways people learn software workflows: tutorial videos.
+
+Video carries temporal order, interface-state changes, animation timing, spatial relationships, and tacit choices that are hard to express in prose. It is also long, repetitive, and expensive to keep in every inference context. Reducing a tutorial to a plain summary removes much of the dynamic evidence that made the video useful.
+
+Resource2Skill does not keep raw videos in the agent's long-term context. It distills videos, repositories, articles, and reference artifacts into a validated multimodal Skill Wiki. At task time, the agent retrieves a small number of relevant Skills. When the offline library has a real coverage gap, the same construction operator can create controlled online candidates.
+
+The system has four stages:
+
+1. **Construction** extracts modality-specific evidence and creates candidate Skills.
+2. **Wiki organization** stores text, visual, code, taxonomy, and provenance views.
+3. **Selection** narrows the hierarchy lexically, then lets a model select a composable subset.
+4. **Execution and online acquisition** applies Skills through MCP and fills genuine gaps with separately managed online candidates.
+
+## 2. The important Resource2Skill mechanisms
+
+### A Skill is more than text
+
+Each wiki entry combines:
+
+- a text view describing mechanism, applicability, inputs, and expected effects;
+- a visual view with key frames, screenshots, previews, or diagrams;
+- a code view containing executable or adaptable procedure fragments;
+- metadata including taxonomy path, tags, provenance, and audit information.
+
+The views serve different purposes. Video captures sequence and visual change. Code preserves exact tool patterns. Articles and reference artifacts add concepts, style, and target-state grounding. The representation ablation supports this division: curated text alone helps, while visual and code views add further value, and the full multimodal entry performs best across domains.
+
+### Video goes through deterministic preprocessing
+
+Appendix D describes a more concrete construction operator than the high-level diagram. A resource connector retrieves resource bytes. Videos undergo key-frame sampling, repositories use AST-aware code-region extraction, articles are segmented into passages, and reference artifacts receive image preprocessing. A vision-capable language model then produces a structured skill payload from the extracted evidence.
+
+Resource2Skill therefore does not pass a YouTube watch page directly as native video input. The URL is provenance in a manifest; the distiller receives media bytes retrieved and prepared by a connector.
+
+### Model output is followed by deterministic post-processing
+
+The model produces structured JSON fields such as `skill_name`, `category_path`, `applicability`, tags, text, code, visual caption, and provenance. A deterministic post-processor normalizes formatting, validates the JSON shape, computes a stable identifier from domain/source/node information, and writes the entry.
+
+The language model proposes structured knowledge, but does not independently decide that the candidate is trustworthy.
+
+### Five gates define an acceptable Skill
+
+Resource2Skill applies five independent deterministic checks:
+
+| Gate                     | What it checks                                       | Failure prevented                    |
+| ------------------------ | ---------------------------------------------------- | ------------------------------------ |
+| Completeness             | Required fields, minimum body, at least one modality | Empty or truncated entries           |
+| Provenance               | Source resolves through the connector manifest       | Invented or untraceable sources      |
+| Deduplication            | Stable IDs and normalized same-source names          | Repeated pollution from one resource |
+| Modality consistency     | Every declared modality exists on disk               | Metadata/filesystem drift            |
+| Structural executability | Sandboxed import/run and domain render checks        | Plausible-looking but unusable code  |
+
+A structurally failing candidate may remain reference-only, but the default verified-only path filters it out. This is a better production state model than a single generated/not-generated flag.
+
+### Retrieval is not just vector similarity
+
+MetaBrowse scores names, tags, applicability text, and taxonomy paths to narrow the candidate hierarchy. A language model then selects zero, one, or multiple complementary Skills.
+
+The selection ablation reports that hierarchy-then-LM beats BM25, embeddings, hybrid retrieval, and random full-pool sampling. Topical similarity is not the same as task fit or composability.
+
+### Online acquisition fills gaps instead of expanding every prompt
+
+Online acquisition uses the same connector, distiller, and validator only when the offline set is inadequate. Online candidates remain separate from the offline pool during evaluation.
+
+The paper reports little benefit on ordinary tasks whose common operations are already covered, but a clear benefit on stress tasks designed around missing capabilities. The practical default is a stable offline library plus controlled gap filling—not unrestricted web expansion for every request.
+
+## 3. How to interpret the experiments
+
+Resource2Skill evaluates Web, Excel, Reaper, PowerPoint, Blender, CAD, and UE5 across four agent backends. The reliable high-level findings are:
+
+1. The Skill system beats the no-Skill condition in every main model-domain aggregate cell.
+2. Gains are largest in convention-heavy workflows such as Web, Blender, and UE5, and smallest in Reaper.
+3. Video is non-substitutable in the source ablation. Code, articles, and reference artifacts do not fully recover temporal and visual-sequence information when video is removed.
+4. Appendix J includes both successes and failures. Failures often come from partial grounding, unresolved symbolic bindings, or overly literal composition—not just API execution errors.
+
+The paper does not claim that every single video distillation is correct. Structural executability means code can run and produce a non-trivial artifact; it does not prove semantic fidelity to every future task.
+
+## 4. Why Qwen Code `/learn`
+
+Qwen Code `/learn` already converts files, directories, URLs, text, or the current conversation into project Skills. The original route submits a text prompt to the main agent. URLs are read with `web_fetch`, and the agent writes `SKILL.md` under `.qwen/skills/learned-skill-*`.
+
+The existing system already provides:
+
+- project Skill storage, discovery, and lazy loading;
+- main-agent file tools and workspace security boundaries;
+- an OpenAI-compatible content converter that maps video parts to `video_url`;
+- effective input-modality declarations in the model registry.
+
+The missing piece is a native video route. A tutorial URL currently exposes webpage metadata rather than media, and a local video has no video-specific distillation contract.
+
+This first implementation deliberately supports only models that already accept video. It does not add a text-only fallback or silently switch models. That keeps video-model quality, transcription quality, and frame-sampling quality from being mixed into one uninterpretable result.
+
+## 5. Qwen Code implementation
+
+### Input recognition
+
+`/learn` treats the first non-empty token as the resource and the remaining text as an optional focus. The video route recognizes:
+
+- local `.mp4`, `.webm`, `.mov`, and `.m4v` files;
+- HTTP(S) URLs whose pathname ends with one of those extensions;
+- YouTube watch, shorts, live, embed, and `youtu.be` pages as webpages that must not be sent as media files.
+
+Ordinary webpages and text retain the original `/learn` behavior.
+
+### Model and provider capability gates
+
+A video request requires both:
+
+- effective `modalities.video=true` on the current model;
+- an OpenAI-compatible or Qwen OAuth generator path.
+
+Otherwise the command fails before provider submission, preventing the converter from silently replacing video with a text placeholder.
+
+### Local video security boundaries
+
+Local media uses the existing workspace-aware reader. Absolute paths must remain inside an allowed workspace, relative paths resolve only against workspace directories, ignore rules remain active, and existing MIME and inline-data limits apply.
+
+The resulting `video/*` inline part becomes a `data:video/...;base64,...` OpenAI `video_url`.
+
+### Direct files versus YouTube pages
+
+Direct HTTP(S) video files use `fileData` and are fetched by the provider. YouTube pages are rejected with guidance to download the video and pass a local file.
+
+This boundary follows both evidence and architecture. A watch page is not media bytes, and Resource2Skill itself relies on a connector before preprocessing. This change does not introduce a downloader, cookies, site-specific policy, or media caching.
+
+### Video-specific distillation contract
+
+The video route asks the main agent to create exactly:
+
+```text
+.qwen/skills/learned-skill-<name>/
+├── SKILL.md
+└── references/
+    └── source.md
+```
+
+`SKILL.md` requires a valid lowercase kebab-case name, description, `source: learned`, specific `when_to_use`, and Prerequisites, Procedure, Verification, Pitfalls, and Boundaries sections.
+
+`references/source.md` records the resource, focus, exact status `source-grounded, not execution-verified`, and an evidence map connecting video timestamps, observed evidence, and Skill sections.
+
+The prompt also treats speech, captions, on-screen text, and metadata as untrusted data; prohibits executing tutorial commands or installing dependencies; rejects guessed commands/selectors/literals; forbids permission expansion; and prevents claims of execution verification.
+
+### Deliberate scope boundaries
+
+This change does not add video downloading, transcoding, segmentation, transcription, key-frame extraction, one-video-to-many-Skills, taxonomy indexing, deterministic post-generation acceptance, or new Gemini/Vertex transport.
+
+The missing acceptance layer becomes decisive in the real E2E result.
+
+## 6. Model configuration: 256K context and no thinking mode
+
+The test uses `qwen3.5-omni-plus`. The [Qwen Cloud vision documentation](https://docs.qwencloud.com/developer-guides/getting-started/vision-models) lists text, image, audio, and video input, one maximum video, a 256K context window, 64K maximum output, and one hour maximum video duration.
+
+The correct configuration is:
+
+```json
+{
+  "id": "qwen3.5-omni-plus",
+  "generationConfig": {
+    "contextWindowSize": 262144,
+    "modalities": {
+      "image": true,
+      "audio": true,
+      "video": true
+    }
+  }
+}
+```
+
+64K is the maximum output, not context. There is no `extra_body.enable_thinking`: the Qwen Cloud [thinking FAQ](https://docs.qwencloud.com/resources/faq-text-generation) explicitly states that Qwen3.5-Omni does not support thinking mode. Empirically, adding the flag still produced zero reasoning content and zero thought tokens.
+
+## 7. Real tutorial case and test design
+
+Appendix J presents task briefs and produced artifacts, but does not enumerate a tutorial URL for each qualitative case. The released Skill library metadata does preserve source URLs.
+
+The selected official entry is [Sliced Typography Hover Effect](https://github.com/microsoft/Resource2Skill/blob/main/skills_library/web/navigation/sliced_typography_hover_effect_68a7d75a/skill.json):
+
+- source tutorial: [Split Text on Hover](https://www.youtube.com/watch?v=vOlZg1LRFp0);
+- metadata duration: 896 seconds; downloaded MP4 measured by `ffprobe`: 895.2 seconds;
+- file size: 6,533,189 bytes;
+- SHA-256: `92cee2611ebbf1e74c4643d6e9c0f3c05feceb1e6e6e0c78ba6d50f305341084`.
+
+This case has a complete source video, released metadata, precise HTML/CSS mechanics, and browser-measurable hover states without proprietary software.
+
+The official mechanics include `data-text` duplication into anchor pseudo-elements, complementary 50% clip paths, top/bottom transforms of `(10px, -2px)` and `(-10px, 2px)`, a shared red accent, and a line contained by a positioned overflow-hidden item while sweeping across it.
+
+## 8. Test sequence and results
+
+### YouTube page as native `video_url`
+
+The exact YouTube URL was first sent as one video part. Request logging confirmed the model and `video_url`, but no provider response arrived within five minutes. Cancellation produced no files.
+
+A reachable watch page is not evidence that the provider obtained a media stream.
+
+### Full MP4 through a temporary HTTPS URL
+
+The complete MP4 was then exposed through a temporary HTTPS URL. The local server observed multiple successful GETs, but the model request timed out after 483 seconds.
+
+This demonstrated remote retrieval attempts, but not an acceptable end-to-end result.
+
+### Original generic `/learn` with the complete local MP4
+
+The video was copied into an isolated workspace and passed through the old generic route. The provider accepted roughly 180K video tokens and returned, proving that `qwen3.5-omni-plus` could process the full tutorial.
+
+The old path created only `SKILL.md`, omitted provenance, and generated incorrect selectors, color values, transforms, and line endpoints. Transport was not the remaining problem; the route needed a video-specific contract and validation.
+
+### New local-video `/learn` route
+
+The final run used isolated project, runtime, logs, and `QWEN_HOME` directories, with an explicit 262144 context, video modality, and no thinking flag.
+
+One `/learn` invocation created exactly:
+
+```text
+learned-skill-sliced-typography/SKILL.md
+learned-skill-sliced-typography/references/source.md
+```
+
+Passing checks:
+
+- the first request carried one full inline MP4 `video_url`;
+- every transcript assistant entry recorded `contextWindowSize: 262144`;
+- the frontmatter name `sliced-typography` was loadable;
+- provenance status exactly matched the contract;
+- the evidence map contained 18 timestamp ranges;
+- no third artifact was created.
+
+After both write tools succeeded, the optional closing response encountered one token-limit 429 and one terminated connection. This is recorded as no closing verdict, not as failed file creation.
+
+### Fresh-session Skill invocation
+
+A new session in the same project was explicitly instructed to invoke the learned Skill before creating a demo. The transcript recorded:
+
+```text
+skill({"skill":"sliced-typography"})
+```
+
+It then created only `demo/index.html`. This prevents the previous video's conversation context from being mistaken for Skill reuse.
+
+### Browser validation with Playwright
+
+The browser test measured real DOM and pseudo-element computed styles:
+
+- five menu items and zero scripts;
+- `"Home"` content in both pseudo-elements;
+- complementary top/bottom clip polygons;
+- final transforms `(10, -2)` and `(-10, 2)`;
+- line `left` moving from `-296.781px` to `296.781px`;
+- no page errors; the only console error was an irrelevant missing favicon.
+
+This proves that the sliced-text motion actually ran in a browser.
+
+## 9. The final fidelity failure
+
+The learned `SKILL.md` still contained three important defects:
+
+1. hover selectors omitted the anchor, colliding with the line's `li::before` role;
+2. default pseudo-element color was missing while the anchor was transparent;
+3. line positioning, containing block, and overflow constraints were not fully bound to the item.
+
+The fresh application session corrected the selector, default color, and transforms, but introduced two deviations:
+
+- the shared official red became pink and cyan;
+- each `li` remained `position: static`, making the line's containing block the whole `ul`.
+
+Playwright measured:
+
+| Measurement     | Y coordinate |
+| --------------- | -----------: |
+| Home row center |          272 |
+| Sweeping line   |        449.5 |
+| Error           |     177.5 px |
+
+The line crossed Services instead of the hovered Home row. The final verdict is therefore:
+
+| Layer                                          | Result |
+| ---------------------------------------------- | ------ |
+| Native video transport                         | PASS   |
+| Two-file provenance contract                   | PASS   |
+| Valid Skill name and loading                   | PASS   |
+| Fresh-session Skill invocation                 | PASS   |
+| Renderable pure-CSS demo                       | PASS   |
+| Structural and visual fidelity to the tutorial | FAIL   |
+
+<Callout type="warning">
+  “The model saw the video,” “files were generated,” “the Skill was invoked,”
+  and “the artifact opens” are not substitutes for behavioral validation. This
+  case required measuring the line's containing block to expose the real error.
+</Callout>
+
+## 10. Code-level verification
+
+The change includes parser, prompt-builder, command-routing, locale, and focused test coverage. Validation commands:
+
+```bash
+cd packages/core
+npx vitest run src/memory/learn-skill-agent.test.ts
+
+cd ../cli
+npx vitest run src/ui/commands/learn-command.test.ts
+
+cd ../..
+npm run build
+npm run typecheck
+npm run bundle
+```
+
+Final results:
+
+- core focused tests: 36/36;
+- CLI focused tests: 11/11;
+- both focused ESLint runs: pass;
+- repository build: pass;
+- typecheck: pass;
+- bundle: pass;
+- `git diff --check`: pass.
+
+## 11. What was borrowed, and what remains
+
+| Resource2Skill concept                        | Current Qwen Code state                                      |
+| --------------------------------------------- | ------------------------------------------------------------ |
+| Vision-capable LM distillation                | Implemented: native video enters the current model           |
+| Separate Skill and source evidence            | Implemented: `SKILL.md` plus `references/source.md`          |
+| Timestamp provenance                          | Implemented as an evidence-map contract                      |
+| Untrusted resource boundary                   | Implemented in the prompt                                    |
+| Modality/capability gate                      | Implemented for model and provider                           |
+| Resource connector                            | Partial: local workspace reader; no network-video downloader |
+| Deterministic key-frame preprocessing         | Not implemented                                              |
+| Structured intermediate JSON                  | Not implemented                                              |
+| Stable ID and deduplication                   | Existing directory-collision rules only                      |
+| Deterministic schema/provenance validation    | Not implemented                                              |
+| Sandboxed structural executability            | Not implemented                                              |
+| Verified-only/reference-only states           | Not implemented                                              |
+| Taxonomy, hierarchical retrieval, composition | Not implemented                                              |
+| Controlled online acquisition                 | Not implemented                                              |
+
+## 12. Recommended next stage
+
+The next change should establish a minimum acceptance loop before adding more video sites or models:
+
+1. **Deterministic schema gate**: parse frontmatter and validate name, directory, required sections, two-file contract, and exact provenance status.
+2. **Evidence gate**: validate timestamp format, referenced sections, and source membership in the current resource manifest.
+3. **Structured candidate**: request constrained JSON, then let Qwen Code write files deterministically instead of letting free-form tool calls choose paths and schema.
+4. **Domain validator**: for HTML/CSS Skills, generate a minimal fixture and use a sandboxed browser to check selector matches, pseudo-element ownership, containing blocks, overflow, and state transitions.
+5. **State separation**: mark accepted candidates verified; keep source-grounded but unexecuted candidates reference-only and out of the default executable path.
+6. **Connector after validation**: then add downloading, transcoding, key-frame sampling, and caching. Keep a YouTube URL as provenance rather than pretending it is media bytes.
+
+## Conclusion
+
+The most transferable idea in Resource2Skill is not a particular video prompt. It is the engineering boundary between a multimodal model that proposes candidate knowledge and a deterministic system that decides whether the candidate can enter an executable capability library.
+
+Native video `/learn` proved that a full tutorial can reach the model, produce a Skill, be discovered, and be invoked in a fresh session. The same real case also proved that without post-processing and acceptance gates, the result can still fail on one CSS containing block.
+
+The layered result is useful and precise: transport is solved, the distillation contract is partially solved, and trustworthy execution remains the next engineering milestone.
+
+## References
+
+- [Resource2Skill paper](https://arxiv.org/abs/2606.29538)
+- [Resource2Skill official repository](https://github.com/microsoft/Resource2Skill)
+- [RESOURCE2SKILL dataset](https://huggingface.co/datasets/microsoft/RESOURCE2SKILL)
+- [Official Sliced Typography Skill entry](https://github.com/microsoft/Resource2Skill/blob/main/skills_library/web/navigation/sliced_typography_hover_effect_68a7d75a/skill.json)
+- [Original video tutorial](https://www.youtube.com/watch?v=vOlZg1LRFp0)
+- [Qwen Cloud vision model documentation](https://docs.qwencloud.com/developer-guides/getting-started/vision-models)
+- [Qwen Cloud thinking mode FAQ](https://docs.qwencloud.com/resources/faq-text-generation)

--- a/website/content/zh/blog/advanced/_meta.ts
+++ b/website/content/zh/blog/advanced/_meta.ts
@@ -1,6 +1,9 @@
 export default {
-  index: { display: 'hidden' },
-  'qwencode-bailian-ai-marketing': '百炼 CLI + Qwen Code 搞定电商营销全流程',
-  'qwencode-mpcover-skill-guide': '一句话生成封面：我给公众号做了4种风格的AI封面生成技能',
-  'feat-skills-oss-styles': '一句话，给你的开源项目拍部电影级宣传片',
+  index: { display: "hidden" },
+  "qwencode-bailian-ai-marketing": "百炼 CLI + Qwen Code 搞定电商营销全流程",
+  "qwencode-mpcover-skill-guide":
+    "一句话生成封面：我给公众号做了4种风格的AI封面生成技能",
+  "feat-skills-oss-styles": "一句话，给你的开源项目拍部电影级宣传片",
+  "resource2skill-qwencode-video-learn":
+    "从视频教程到可复用 Skill：Resource2Skill 与 Qwen Code /learn 实践",
 };

--- a/website/content/zh/blog/advanced/resource2skill-qwencode-video-learn.mdx
+++ b/website/content/zh/blog/advanced/resource2skill-qwencode-video-learn.mdx
@@ -1,0 +1,425 @@
+---
+title: "从视频教程到可复用 Skill：Resource2Skill 论文分析与 Qwen Code /learn 实践"
+date: "2026-07-22"
+description: "深入分析 Resource2Skill 的构建、检索与验收机制，并记录 Qwen Code /learn 原生视频输入的实现、真实教程测试和工程结论"
+author: "LaZzyMan"
+tags: ["Research", "Skills", "Video", "Qwen Code", "Engineering"]
+---
+
+import { BlogPostHeader } from "@/components/blog-post-header";
+import { Callout } from "nextra/components";
+
+<BlogPostHeader
+  title="从视频教程到可复用 Skill：Resource2Skill 论文分析与 Qwen Code /learn 实践"
+  date="2026-07-22"
+  author="LaZzyMan"
+/>
+
+把一段人类教程视频直接交给软件 Agent，能不能得到一个以后可以反复调用的 Skill？
+
+这个问题看起来像“让多模态模型总结视频”，但真正落地时至少包含三件不同的事：模型能否接收完整视频、能否把观察压缩成结构化且可检索的过程知识、生成结果能否在真实软件环境中复现原教程。只验证第一件事，很容易把“API 收到了视频”误报成“Skill 已经可用”。
+
+本文围绕微软研究院的 [Resource2Skill 论文](https://arxiv.org/abs/2606.29538) 与 [官方开源实现](https://github.com/microsoft/Resource2Skill)，分析其资源构建、Skill Wiki、检索、在线获取和确定性验收机制，并记录一次将原生视频输入接入 Qwen Code `/learn` 的完整工程实验。
+
+结论先行：
+
+- Resource2Skill 的核心贡献不是“用视觉模型看视频”，而是把多模态蒸馏、结构化存储、检索和确定性验收组成一条闭环流水线。
+- Qwen Code 已经具备 Skill 文件系统、主 Agent 写文件、OpenAI 兼容视频传输和模型模态声明，适合先补齐 `/learn` 的原生视频入口。
+- 本次实现已真实跑通“完整本地视频 → 两文件 Skill → 新会话发现并调用 Skill → 生成浏览器产物”的链路。
+- 对官方教程的最终忠实度验收仍然失败：文字切片动画正确，扫线却绑定到了错误的 containing block。链路可用不等于蒸馏结果可信。
+- 下一阶段不应继续堆提示词，而应借鉴论文补上确定性的 schema、provenance、结构执行与渲染验收 gate。
+
+## 一、论文到底解决了什么问题
+
+现有 Skill 通常来自三类来源：专家手写、Agent 自身轨迹、文本或代码语料。它们容易忽略人类最常用的学习载体之一：教程视频。
+
+视频有两种互相冲突的特征。一方面，它能表达操作先后顺序、界面状态变化、动画节奏、空间关系和难以文字化的隐性选择；另一方面，原始视频长、重复、成本高，直接塞进每次推理既浪费上下文，也不适合作为可组合记忆。把视频压成普通摘要又会丢失最有价值的动态证据。
+
+Resource2Skill 的回答不是长期保存原始视频上下文，而是把视频、代码仓库、文章和参考产物统一蒸馏为经过验证的多模态 Skill Wiki。Agent 在执行任务时只检索少量相关 Skill；离线库覆盖不足时，再复用同一个构建算子做受控的在线补充。
+
+这使“资源到能力”的过程被拆成四个阶段：
+
+1. **Construction**：从资源中提取模态相关证据并生成候选 Skill。
+2. **Wiki organization**：按领域 taxonomy 组织文本、视觉、代码和 provenance。
+3. **Selection**：先用层级与词法信号缩小范围，再由模型选择一个可组合子集。
+4. **Execution and online acquisition**：通过统一 MCP 接口应用 Skill；覆盖不足时在线获取临时候选。
+
+## 二、Resource2Skill 的关键机制
+
+### 1. Skill 不是一段文本，而是三个互补视图
+
+论文中的 Wiki 条目同时保留：
+
+- 文本视图：名称、适用场景、机制、输入和预期效果；
+- 视觉视图：关键帧、截图、预览或示意图；
+- 代码视图：可执行或可改写的过程片段；
+- 元数据：taxonomy path、标签、来源和审计信息。
+
+这里的设计重点是信息分工。视频擅长表达时间顺序和视觉变化；代码擅长保存精确调用模式；文章和参考产物补足概念、风格与目标状态。Ablation 的方向性结果也支持这一点：纯文本 Skill 已经优于无 Skill，但加入视觉和代码后仍继续提升；完整多模态条目在各领域表现最好。
+
+### 2. 视频先经过确定性预处理
+
+论文 Appendix D 对构建算子给出了比正文更具体的描述：资源 connector 先取回资源 bytes；视频执行关键帧采样，代码执行 AST-aware 区域抽取，文章做段落切分，参考产物做图像预处理；然后视觉语言模型按领域模板生成结构化 Skill payload。
+
+因此，Resource2Skill 并不是把 YouTube watch page 当成 `video_url` 直接交给模型。网页 URL 只是 manifest 中的 provenance；真正进入蒸馏器的是 connector 获取并预处理后的媒体内容。
+
+### 3. 模型输出后还有确定性 post-processing
+
+模型生成包含 `skill_name`、`category_path`、`applicability`、tags、text、code、visual caption 和 provenance 的结构化 JSON。后处理器再完成：
+
+- 空白与格式规范化；
+- JSON shape 校验；
+- 基于领域、来源路径和节点索引生成稳定 ID；
+- 写入磁盘。
+
+模型负责提取和组织候选知识，但不独自决定候选是否可信。
+
+### 4. 五个 gate 才是“可用 Skill”的边界
+
+论文的 acceptance predicate 包含五个互相独立的确定性检查：
+
+| Gate                     | 检查内容                                                       | 防止的问题           |
+| ------------------------ | -------------------------------------------------------------- | -------------------- |
+| Completeness             | 必需字段、最小正文、至少一种内容模态                           | 空壳或截断条目       |
+| Provenance               | 来源必须存在于 connector manifest 且可解析                     | 编造或不可追踪来源   |
+| Deduplication            | 稳定 ID 与同源规范化名称去重                                   | 同一资源反复污染库   |
+| Modality consistency     | 声明的视觉、代码等文件必须真实存在                             | metadata 与磁盘脱节  |
+| Structural executability | 在 sandbox 中导入/运行代码，并按领域执行 render/overlap 等检查 | 看起来合理但无法运行 |
+
+值得注意的是，结构执行失败的候选可以作为 reference-only 保留，但不会进入默认 verified-only 执行路径。这个状态区分比“生成成功/失败”更适合真实 Agent 系统。
+
+### 5. 检索不是简单向量相似度
+
+MetaBrowse 先把 Skill 的名称、标签、适用文本和 taxonomy path 交给词法评分器，将候选缩小到相关子树，再让模型选择一个子集。模型可以选择零个 Skill，也可以组合多个互补 Skill。
+
+论文的 selection ablation 显示，hierarchy-then-LM 策略优于 BM25、embedding、二者组合和随机抽取。这说明“主题相似”不足以代表“能否一起完成任务”；适用性、互补性和执行绑定仍需要显式判断。
+
+### 6. Online acquisition 是补洞，不是默认扩上下文
+
+在线获取只在离线候选覆盖不足时触发，使用与离线构建相同的 connector、蒸馏器和验收规则。在线候选与离线库在实验中分开保存，不会未经控制地回写正式库。
+
+论文报告的方向性结果是：普通任务上在线获取收益接近噪声；在特意覆盖离线能力缺口的 stress set 上才有明显价值。因此更合理的默认是稳定离线库，加受控 gap-filling，而不是每次任务都上网扩张记忆。
+
+## 三、论文实验应如何解读
+
+论文覆盖 Web、Excel、Reaper、PPT、Blender、CAD 和 UE5 七个创作领域，并在四个 Agent backend 上比较有 Skill、无 Skill及两种现成 agent harness。
+
+可以稳妥得到四个结论：
+
+1. 有 Skill 的系统在主实验的全部 model-domain aggregate cells 中优于无 Skill。
+2. 最大收益集中在约定密集、需要重建复杂工作流的领域，例如 Web、Blender 和 UE5；Reaper 的增益最小。
+3. 视频是 source ablation 中不可替代的来源。移除视频后，代码、文章和参考产物不能完全补回时间操作与视觉序列信息。
+4. 论文 Appendix J 同时公开成功与失败案例。失败主要来自部分 grounding、符号绑定没有解析、或 Agent 过度字面地组合 Skill，而不是简单的 API 执行失败。
+
+这些结论也限定了论文不能证明的内容：它没有证明单次视频蒸馏必然正确，也没有证明所有生成代码都语义忠实；结构 executability 只保证候选可运行并产生非平凡产物，不保证它解决任意具体任务。
+
+## 四、为什么选择接入 Qwen Code `/learn`
+
+Qwen Code 已有 `/learn`：它把文件、目录、URL、文本或当前对话转换为项目级 Skill。原来的路径最终向主 Agent 提交一段文字 prompt；URL 由 `web_fetch` 读取，主 Agent 在 `.qwen/skills/learned-skill-*` 下写入 `SKILL.md`。
+
+这套基础设施已经提供四个关键组件：
+
+- 项目级 Skill 存储、发现和按需加载；
+- 主 Agent 的文件工具与 workspace 安全边界；
+- OpenAI 兼容 content converter，可将视频 part 转为 `video_url`；
+- 模型 registry 中的有效输入模态声明。
+
+缺口是：教程视频 URL 仍会走网页抓取，模型只能看到页面 metadata，而看不到真实视频；本地视频也没有 video-specific distillation contract。
+
+本阶段明确限制为“只支持本身具有视频输入能力的模型”，不做 text-only fallback，也不自动切换模型。这样可以先验证最短的原生链路，避免把转录质量、抽帧质量和视频模型质量混成一个不可解释的结果。
+
+## 五、Qwen Code 实现
+
+### 1. 输入识别
+
+`/learn` 将第一个非空 token 解析为资源，其余文本作为可选 focus。视频输入只识别明确格式：
+
+- 本地 `.mp4`、`.webm`、`.mov`、`.m4v`；
+- pathname 以这些扩展名结尾的 HTTP(S) 直链；
+- YouTube watch、shorts、live、embed 和 `youtu.be` 页面会被识别，但不会当成原生媒体文件发送。
+
+普通网页和文本继续走原有 `/learn` 行为。
+
+### 2. 模型与 provider capability gate
+
+提交视频前必须同时满足：
+
+- 当前有效模型声明 `modalities.video=true`；
+- 当前生成器是 OpenAI-compatible 或 Qwen OAuth 路径。
+
+不满足时，命令在发起 provider 请求前返回明确错误，避免视频被 content converter 静默替换成占位文本。
+
+### 3. 本地视频安全边界
+
+本地资源复用已有 workspace-aware reader，因此继续受以下规则约束：
+
+- 绝对路径必须位于允许的 workspace；
+- 相对路径只在 workspace 目录内解析；
+- respect `.gitignore` 与 `.qwenignore`；
+- 复用已有 MIME 检测和 inline media 大小上限。
+
+成功读取后，命令提取 `video/*` inline part，由 OpenAI converter 转为 `data:video/...;base64,...` 的 `video_url`。
+
+### 4. 直链与 YouTube 的不同处理
+
+直达视频文件的 HTTP(S) URL 使用 `fileData`，由 provider 获取资源。YouTube 页面则在本地直接拒绝，并提示先下载视频再传本地文件。
+
+这不是任意限制，而是实测结果与论文架构共同决定的：YouTube page 并不是视频 bytes；Resource2Skill 也依赖 connector 下载资源后再预处理。本阶段没有引入 downloader、cookies、站点条款处理或媒体缓存，所以不能把 watch page 支持伪装成视频支持。
+
+### 5. Video-specific distillation contract
+
+视频路径要求主 Agent 只创建：
+
+```text
+.qwen/skills/learned-skill-<name>/
+├── SKILL.md
+└── references/
+    └── source.md
+```
+
+`SKILL.md` 必须包含合法的 lowercase kebab-case name、description、`source: learned`、具体 `when_to_use`，以及 Prerequisites、Procedure、Verification、Pitfalls、Boundaries。
+
+`references/source.md` 记录来源、focus、精确状态 `source-grounded, not execution-verified`，并用“视频时间戳—观察证据—Skill 章节”组成 evidence map。
+
+Prompt 还明确要求：
+
+- 把视频语音、字幕、画面文字和 metadata 当成不可信数据；
+- 不执行教程命令，不安装依赖，不与教程中的服务交互；
+- 看不清的 selector、命令或 literal 不得猜测；
+- 不添加 allowed tools、hooks、model override 或权限；
+- 不声称已经执行验证。
+
+### 6. 当前没有实现的部分
+
+为了保持首个变更可审查，本阶段没有加入：
+
+- 视频下载、转码、分段、转录或关键帧抽取；
+- YouTube 页面直接摄取；
+- 一段视频生成多个 Skill；
+- taxonomy 与检索索引；
+- 生成后的 deterministic schema/lint/render acceptance gate；
+- Gemini 或 Vertex provider 的新视频传输。
+
+最后一项缺口在真实 E2E 中成为决定性问题。
+
+## 六、模型配置：256K context，不支持 thinking
+
+测试模型为 `qwen3.5-omni-plus`。根据 [Qwen Cloud 视觉模型文档](https://docs.qwencloud.com/developer-guides/getting-started/vision-models)，它支持 text、image、audio、video 输入，最多一个视频，context 为 256K，max output 为 64K，最大视频时长一小时。
+
+因此测试配置为：
+
+```json
+{
+  "id": "qwen3.5-omni-plus",
+  "generationConfig": {
+    "contextWindowSize": 262144,
+    "modalities": {
+      "image": true,
+      "audio": true,
+      "video": true
+    }
+  }
+}
+```
+
+64K 是最大输出，不是上下文。配置中也没有 `extra_body.enable_thinking`：Qwen Cloud [Thinking mode FAQ](https://docs.qwencloud.com/resources/faq-text-generation) 明确说明 Qwen3.5-Omni 不支持 thinking mode。实测即使发送该 flag，响应中的 `reasoning_content` 和 thoughts token 仍为零，因此不应把一个无效参数当作推理增强。
+
+## 七、真实教程案例与测试方法
+
+论文 Appendix J 的 qualitative case studies 展示的是任务 brief 与最终产物，不逐条列出原始教程 URL。作者发布的 Skill library metadata 则保留了真实来源。
+
+本次选择官方条目 [Sliced Typography Hover Effect](https://github.com/microsoft/Resource2Skill/blob/main/skills_library/web/navigation/sliced_typography_hover_effect_68a7d75a/skill.json)：
+
+- 原始教程：[Split Text on Hover](https://www.youtube.com/watch?v=vOlZg1LRFp0)；
+- 视频时长：metadata 为 896 秒，下载文件经 `ffprobe` 测得 895.2 秒；
+- 文件大小：6,533,189 bytes；
+- SHA-256：`92cee2611ebbf1e74c4643d6e9c0f3c05feceb1e6e6e0c78ba6d50f305341084`。
+
+选择该案例是因为它同时具备：完整原视频、作者生成的 Skill metadata、明确 HTML/CSS 结构、可在浏览器中测量的 hover 状态，以及不依赖商业软件的复现环境。
+
+官方实现的关键真值包括：
+
+- anchor 通过 `data-text` 向 `::before`、`::after` 复制文本；
+- top/bottom 使用互补的 50% `clip-path`；
+- top hover 位移 `(10px, -2px)`，bottom 为 `(-10px, 2px)`；
+- 两半切换为红色；
+- 扫线必须在 positioned、overflow-hidden item 内从一侧完整扫到另一侧。
+
+## 八、测试流程与逐轮结果
+
+### 1. YouTube page 直接作为 `video_url`
+
+第一轮把官方 YouTube URL 原样作为一个视频 part 发送。请求日志确认模型、参数和 `video_url` 都正确，但五分钟内没有 provider response，取消后没有生成文件。
+
+结论：watch page 可访问不等于 provider 能取到媒体流，不能把无响应算成视频理解失败或成功。
+
+### 2. 完整 MP4 通过临时 HTTPS 直链
+
+第二轮将同一个完整 MP4 暴露为临时 HTTPS URL。本地服务器观察到多次成功 GET，说明 provider 已尝试获取资源，但模型请求在 483 秒后超时。
+
+结论：远端视频直链传输路径成立，但这个临时链路没有形成可接受的端到端结果。
+
+### 3. 修改前的通用 `/learn` + 本地完整 MP4
+
+第三轮把完整视频复制到隔离 workspace，通过原有通用 `/learn` 路径读取。provider 接收约 18 万视频 token 并返回，证明 `qwen3.5-omni-plus` 可以处理这段完整视频。
+
+但旧路径只创建 `SKILL.md`，没有 provenance reference；生成内容还出现 selector、颜色、位移和扫线终点错误。这确认了问题不在“视频能否进入模型”，而在缺少视频专用 contract 与验收。
+
+### 4. 新实现的 `/learn` 本地视频路径
+
+最终测试使用新的隔离 project、runtime、logs 与 `QWEN_HOME`，明确配置 262144 context、video modality，并移除 thinking flag。
+
+一次 `/learn` 创建且只创建：
+
+```text
+learned-skill-sliced-typography/SKILL.md
+learned-skill-sliced-typography/references/source.md
+```
+
+通过项：
+
+- 第一请求包含一个完整 MP4 inline `video_url`；
+- transcript 全部记录 `contextWindowSize: 262144`；
+- frontmatter name 为可加载的 `sliced-typography`；
+- provenance status 精确匹配 contract；
+- evidence map 覆盖 18 组时间戳；
+- 没有第三个产物文件。
+
+Learn turn 在两次写文件完成后，收尾响应遇到一次 token-limit 429 和一次连接终止，但这不影响已完成的两个 write tool。报告中将其记为“收尾无 verdict”，而不是内容写入失败。
+
+### 5. 新会话显式调用 Skill
+
+在同一 project 启动全新会话，要求先调用 learned Skill，再只基于 Skill 创建 demo。Transcript 明确记录：
+
+```text
+skill({"skill":"sliced-typography"})
+```
+
+随后生成单文件 `demo/index.html`。这一步排除了“模型仍在利用上一轮原始视频上下文”的可能性。
+
+### 6. Playwright 浏览器验收
+
+浏览器测试不只检查文件存在，而是测量真实 DOM 与 pseudo-element computed style：
+
+- 5 个菜单项；
+- 0 个 script；
+- `::before` 与 `::after` 都读取到 `"Home"`；
+- top/bottom clip polygon 互补；
+- hover 后位移分别为 `(10, -2)` 与 `(-10, 2)`；
+- 扫线的 `left` 从 `-296.781px` 移到 `296.781px`；
+- 无 page error，唯一 console error 是无关的 favicon 404。
+
+这些检查证明切片文字动画本身真实工作，而不是静态 HTML 猜测。
+
+## 九、最终失败在哪里
+
+Learned `SKILL.md` 仍有三个关键缺陷：
+
+1. hover selector 写成 `li:hover::before/::after`，漏掉 anchor，和 line 使用的 `li::before` 冲突；
+2. anchor 已设 `color: transparent`，但默认文字 pseudo-element 颜色没有完整定义；
+3. line 的定位、containing block 与 overflow 约束没有被完整绑定到 item。
+
+新会话在生成 demo 时自行修正了 selector、默认颜色和两个位移，却又引入两个偏差：
+
+- 将官方统一红色改为粉色和青色；
+- `li` 仍为 `position: static`，所以 line 的 containing block 实际是整个 `ul`。
+
+Playwright 测得 hover Home 时：
+
+| 测量对象    |   Y 坐标 |
+| ----------- | -------: |
+| Home 行中心 |      272 |
+| 扫线        |    449.5 |
+| 误差        | 177.5 px |
+
+截图中扫线穿过 Services，而不是正在 hover 的 Home。因此最终 verdict 是：
+
+| 层级                         | 结果 |
+| ---------------------------- | ---- |
+| 原生视频传输                 | PASS |
+| 两文件 provenance contract   | PASS |
+| 合法 Skill name 与加载       | PASS |
+| 新会话 Skill invocation      | PASS |
+| 生成可渲染纯 CSS demo        | PASS |
+| 对官方教程的结构与视觉忠实度 | FAIL |
+
+<Callout type="warning">
+  “模型看过视频”“写出了 Skill”“Skill
+  被调用”“产物能打开”都不能替代最终行为验收。本案例直到浏览器测量 line 的
+  containing block 才暴露真正错误。
+</Callout>
+
+## 十、代码级验证
+
+实现包含 parser、prompt builder、command routing、三种 locale 与定向测试。验证命令如下：
+
+```bash
+cd packages/core
+npx vitest run src/memory/learn-skill-agent.test.ts
+
+cd ../cli
+npx vitest run src/ui/commands/learn-command.test.ts
+
+cd ../..
+npm run build
+npm run typecheck
+npm run bundle
+```
+
+最终结果：
+
+- core 定向测试：36/36；
+- CLI 定向测试：11/11；
+- 两组定向 ESLint：通过；
+- repository build：通过；
+- typecheck：通过；
+- bundle：通过；
+- `git diff --check`：通过。
+
+## 十一、从论文借鉴了什么，哪些还没落地
+
+| Resource2Skill 思想                           | 当前 Qwen Code 状态                                |
+| --------------------------------------------- | -------------------------------------------------- |
+| vision-capable LM 蒸馏多模态资源              | 已落地：视频 part 进入当前主模型                   |
+| 来源与 Skill 分离                             | 已落地：`SKILL.md` + `references/source.md`        |
+| timestamp provenance                          | 已落地：evidence map contract                      |
+| 不执行来源中的不可信指令                      | 已落地：prompt security boundary                   |
+| modality/capability gate                      | 已落地：模型与 provider 双 gate                    |
+| resource connector                            | 部分：本地 workspace reader；无网络视频 downloader |
+| deterministic key-frame preprocessing         | 未落地                                             |
+| structured intermediate JSON                  | 未落地                                             |
+| stable ID 与 deduplication                    | 只复用现有目录 collision 规则                      |
+| deterministic schema/provenance validation    | 未落地                                             |
+| sandboxed structural executability            | 未落地                                             |
+| verified-only / reference-only 状态           | 未落地                                             |
+| taxonomy、hierarchical retrieval、composition | 未落地                                             |
+| controlled online acquisition                 | 未落地                                             |
+
+## 十二、下一阶段建议
+
+真实测试表明，下一个 PR 的优先级不应是再支持更多视频网站或模型，而应先建立最小验收闭环：
+
+1. **Deterministic schema gate**：解析 frontmatter，校验 name、目录、必需章节、两文件 contract 和 exact provenance status。
+2. **Evidence gate**：检查 timestamp 格式、引用章节存在、来源在本次 resource manifest 中。
+3. **Structured candidate**：先让模型返回受约束 JSON，再由 Qwen Code 确定性写文件，避免路径和 schema 由自由文本工具调用决定。
+4. **Domain validator**：对 HTML/CSS Skill 生成最小 fixture，在 sandbox 中启动浏览器，检查 selector 命中、pseudo-element owner、containing block、overflow 和前后状态变化。
+5. **状态分层**：验收通过标记 verified；只满足来源与结构要求的候选标记 reference-only，默认不作为执行 Skill 自动加载。
+6. **再做 connector**：在验收闭环存在后，引入下载、转码、关键帧采样和缓存；YouTube URL 只作为 provenance，不直接冒充媒体 bytes。
+
+## 结语
+
+Resource2Skill 最值得借鉴的不是某个视频 prompt，而是一条明确的工程边界：多模态模型负责从复杂资源中提出候选知识，确定性系统负责决定候选能否进入可执行能力库。
+
+Qwen Code `/learn` 的原生视频入口已经证明完整视频可以进入模型、Skill 可以写入、发现并在新会话中使用。真实案例也同样证明，缺少 post-processing 和 acceptance gate 时，结果仍可能在最后一个 CSS containing block 上失败。
+
+这不是一次失败的演示，而是一个有价值的分层结论：transport 已经解决，distillation contract 部分解决，trustworthy execution 仍需要下一阶段的确定性验证。
+
+## 参考资料
+
+- [Resource2Skill 论文](https://arxiv.org/abs/2606.29538)
+- [Resource2Skill 官方代码](https://github.com/microsoft/Resource2Skill)
+- [RESOURCE2SKILL 数据集](https://huggingface.co/datasets/microsoft/RESOURCE2SKILL)
+- [官方 Sliced Typography Skill 条目](https://github.com/microsoft/Resource2Skill/blob/main/skills_library/web/navigation/sliced_typography_hover_effect_68a7d75a/skill.json)
+- [原始视频教程](https://www.youtube.com/watch?v=vOlZg1LRFp0)
+- [Qwen Cloud 视觉模型文档](https://docs.qwencloud.com/developer-guides/getting-started/vision-models)
+- [Qwen Cloud Thinking mode FAQ](https://docs.qwencloud.com/resources/faq-text-generation)


### PR DESCRIPTION
## Summary

- Add bilingual long-form documentation for the Resource2Skill paper and official implementation.
- Explain how native video input was integrated into Qwen Code `/learn`, including capability gates, workspace boundaries, provenance, and model configuration.
- Document the full real-video E2E sequence, browser measurements, fidelity failure, and the deterministic acceptance work still required.
- Register both pages in the Advanced blog navigation.

## Validation

- Compiled both new MDX files with `@mdx-js/mdx` and frontmatter support.
- Ran Prettier checks on both pages and both navigation files.
- Ran `git diff --check`.
- A full site build was attempted from a sparse checkout; generation stopped because untranslated showcase content was intentionally absent from that checkout. The changed MDX files themselves compile successfully.