### PR TITLE
fix: 刷新 9 篇文章封面（内容驱动选物 + 周报禁花）

### DIFF
--- a/website/content/de/blog/advanced/feat-skills-oss-styles.mdx
+++ b/website/content/de/blog/advanced/feat-skills-oss-styles.mdx
@@ -4,7 +4,7 @@ date: "2026-03-18"
 description: "Einführung in Qwen Codes oss-video-Fähigkeit: Geben Sie einfach eine GitHub-Repository-URL ein, und es wird automatisch ein hochwertiges Werbevideo für Ihr Open-Source-Projekt generiert"
 author: "joeytoday"
 tags: ["Tutorials", "Anwenderbeispiele", "Fähigkeiten", "Video"]
-image: https://gw.alicdn.com/imgextra/i4/O1CN01EJM0M11lxqKk7Ct9b_!!6000000004886-2-tps-1344-572.png
+image: https://gw.alicdn.com/imgextra/i4/O1CN017qGRGZ1zEs41Gd6ue_!!6000000006683-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/de/blog/advanced/qwencode-mpcover-skill-guide.mdx
+++ b/website/content/de/blog/advanced/qwencode-mpcover-skill-guide.mdx
@@ -4,7 +4,7 @@ date: "2026-05-29"
 description: "Das Nervigste nach dem Schreiben ist die Suche nach einem Titelbild. Ich habe einen Skill gebaut, der automatisch den Stil wählt, Prompts generiert und Model Studio CLI aufruft, um Bilder basierend auf dem Artikelinhalt zu erstellen. Hier sind die 4 Stile und die Anleitung."
 author: "joeytoday"
 tags: ["Tutorials", "Skills", "Model Studio"]
-image: https://gw.alicdn.com/imgextra/i4/O1CN01Js6CsB1hMVaJFuk4K_!!6000000004263-0-tps-1344-572.jpg
+image: https://gw.alicdn.com/imgextra/i1/O1CN01ZSHWZb1pAcE5XMUAq_!!6000000005320-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/de/blog/cases/obsidian.mdx
+++ b/website/content/de/blog/cases/obsidian.mdx
@@ -4,7 +4,7 @@ date: "2026-03-16"
 description: "Integrieren Sie Qwen Code in Obsidian, um die Effizienz des Wissensmanagements durch Plugin-Installation, Authentifizierungskonfiguration und multimodale Funktionen wie Schreibpolitur, Bildgenerierung und Web-Scraping zu verbessern."
 author: "pomelo-nwu"
 tags: ["Anleitungen", "Benutzerbeispiele"]
-image: https://gw.alicdn.com/imgextra/i2/O1CN01PXEOUq23HOiC2jYkT_!!6000000007230-2-tps-1344-572.png
+image: https://gw.alicdn.com/imgextra/i4/O1CN01lpXwKE24vzQld9Tnc_!!6000000007454-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/de/blog/cases/qwencode-coding-plan-guide-build-website.mdx
+++ b/website/content/de/blog/cases/qwencode-coding-plan-guide-build-website.mdx
@@ -4,7 +4,7 @@ date: "2026-03-06"
 description: "Nutzen Sie Qwen Code, um schnell persönliche Websites zu erstellen, sich an Open-Source-Projekten zu beteiligen und Demovideos zu generieren. Praktischer Leitfaden für KI-Programmiertools."
 author: "joeytoday"
 tags: ["Anleitungen", "Benutzerbeispiele", "Coding Plan"]
-image: https://gw.alicdn.com/imgextra/i2/O1CN01iO8dO31JWXTqKkKVS_!!6000000001036-2-tps-1344-572.png
+image: https://gw.alicdn.com/imgextra/i1/O1CN01bZiyqqomY7C2jBZY_!!6000000001569-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/de/blog/updates/weekly-update-2026-02-03.mdx
+++ b/website/content/de/blog/updates/weekly-update-2026-02-03.mdx
@@ -4,7 +4,7 @@ date: "2026-02-03"
 description: "Diese Woche wurden die stabilen Versionen v0.8.1, v0.8.2 und die Vorschauversion v0.9.0 veröffentlicht mit LSP-Unterstützung, Batch-Runner-Evaluierungstool, einheitlicher UI-Architektur sowie japanischer und portugiesischer Sprachunterstützung."
 author: "Qwen Team"
 tags: ["Product Updates", "release", "weekly"]
-image: https://gw.alicdn.com/imgextra/i1/O1CN01B6SOTZ1v4YgO9SuZF_!!6000000006119-0-tps-1344-576.jpg
+image: https://gw.alicdn.com/imgextra/i4/O1CN01KVv9hF1YZUGa64bnu_!!6000000003073-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/de/blog/updates/weekly-update-2026-03-20.mdx
+++ b/website/content/de/blog/updates/weekly-update-2026-03-20.mdx
@@ -4,7 +4,7 @@ date: "2026-03-20"
 description: "Diese Woche: Token-Limit von 8K auf 16K erhöht, Echtzeit-Token-Verbrauchsanzeige, JetBrains/Zed-Editor-Integration, Plan-Mode-Vergleichsansicht, plus Windows-Kodierungs-Fixes."
 author: "Qwen Team"
 tags: ["Produkt-Updates", "Release", "Wochenbericht"]
-image: https://gw.alicdn.com/imgextra/i4/O1CN012uBaHl1QC77z7o9ZL_!!6000000001939-0-tps-1344-576.jpg
+image: https://gw.alicdn.com/imgextra/i3/O1CN01lm0V1mqnS8D2jBZY_!!6000000002821-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/de/blog/updates/weekly-update-2026-05-07.mdx
+++ b/website/content/de/blog/updates/weekly-update-2026-05-07.mdx
@@ -4,7 +4,7 @@ date: "2026-05-07"
 description: "Diese Woche haben wir v0.15.7 und sechs kleinere Folgeversionen veröffentlicht: DeepSeek V4 mit 1M-Kontext, ein Task-Panel für Hintergrundaufgaben, Gesprächs-Rewind, ein verbessertes Code-Review, Task-Benachrichtigungen, Kostenschätzungen und schnelleren Modellwechsel mit `/model`."
 author: "Qwen Team"
 tags: ["Product Updates", "release", "weekly"]
-image: https://gw.alicdn.com/imgextra/i3/O1CN01VGy00z1RkIIlgXPNF_!!6000000002149-0-tps-1344-576.jpg
+image: https://gw.alicdn.com/imgextra/i2/O1CN01pbkzwbdftEG2jBZY_!!6000000001889-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/de/blog/updates/weekly-update-2026-06-11.mdx
+++ b/website/content/de/blog/updates/weekly-update-2026-06-11.mdx
@@ -4,7 +4,7 @@ date: "2026-06-11"
 description: "Qwen Code v0.18.0-preview bringt /fork Hintergrund-Agenten, /skills visuelle Skill-Verwaltung, benutzerweiten projektübergreifenden Speicher sowie Vim-Modus-Überarbeitung und Standalone-Installer-Auto-Update."
 author: "Qwen Team"
 tags: ["Product Updates", "release", "weekly"]
-image: https://gw.alicdn.com/imgextra/i3/O1CN01jhzdsD1cUgZmWj0JD_!!6000000003604-0-tps-1344-576.jpg
+image: https://gw.alicdn.com/imgextra/i3/O1CN01zBFsOx1vNKvC7sflf_!!6000000006160-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/de/blog/updates/weekly-update-2026-07-16.mdx
+++ b/website/content/de/blog/updates/weekly-update-2026-07-16.mdx
@@ -4,7 +4,7 @@ date: "2026-07-16"
 description: "Diese Woche wurden v0.19.9, v0.19.10 und v0.19.11 veröffentlicht — 3 stabile Versionen mit über 160 gemergten PRs. /learn-Befehl zum Erstellen wiederverwendbarer Skills, Code Review mit Verifier und Reverse-Audit, Web Shell mit shadcn-Überarbeitung und Artifact-Panel, Voice Bridge für Spracheingabe, PDF-zu-Bild-Fallback, CLI /update zum Ein-Klick-Upgrade."
 author: "Qwen Team"
 tags: ["Product Updates", "release", "weekly"]
-image: https://gw.alicdn.com/imgextra/i1/O1CN010k55XR1ZpnzarYSDW_!!6000000003244-0-tps-1344-576.jpg
+image: https://gw.alicdn.com/imgextra/i1/O1CN01rCacTOSznNB2jBZY_!!6000000002069-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/en/blog/advanced/feat-skills-oss-styles.mdx
+++ b/website/content/en/blog/advanced/feat-skills-oss-styles.mdx
@@ -4,7 +4,7 @@ date: "2026-03-18"
 description: "Introducing Qwen Code's oss-video skill: just provide a GitHub repository URL, and it automatically generates a high-quality promotional video for your open source project"
 author: "joeytoday"
 tags: ["Tutorials", "user examples", "Skills", "Video"]
-image: https://gw.alicdn.com/imgextra/i4/O1CN01EJM0M11lxqKk7Ct9b_!!6000000004886-2-tps-1344-572.png
+image: https://gw.alicdn.com/imgextra/i4/O1CN017qGRGZ1zEs41Gd6ue_!!6000000006683-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/en/blog/advanced/qwencode-mpcover-skill-guide.mdx
+++ b/website/content/en/blog/advanced/qwencode-mpcover-skill-guide.mdx
@@ -4,7 +4,7 @@ date: "2026-05-29"
 description: "Finding cover images is the most annoying part of writing articles. I built a Skill that automatically picks a style, generates prompts, and calls Model Studio CLI to create images based on article content. Here are the 4 styles and how to use it."
 author: "joeytoday"
 tags: ["Tutorials", "Skills", "Model Studio"]
-image: https://gw.alicdn.com/imgextra/i4/O1CN01Js6CsB1hMVaJFuk4K_!!6000000004263-0-tps-1344-572.jpg
+image: https://gw.alicdn.com/imgextra/i1/O1CN01ZSHWZb1pAcE5XMUAq_!!6000000005320-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/en/blog/cases/obsidian.mdx
+++ b/website/content/en/blog/cases/obsidian.mdx
@@ -4,7 +4,7 @@ date: "2026-03-16"
 description: "Integrate Qwen Code into Obsidian to enhance knowledge management efficiency through plugin installation, authentication configuration, and multimodal capabilities like writing polish, image generation, and web scraping."
 author: "pomelo-nwu"
 tags: ["Tutorials", "user examples"]
-image: https://gw.alicdn.com/imgextra/i2/O1CN01PXEOUq23HOiC2jYkT_!!6000000007230-2-tps-1344-572.png
+image: https://gw.alicdn.com/imgextra/i4/O1CN01lpXwKE24vzQld9Tnc_!!6000000007454-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/en/blog/cases/qwencode-coding-plan-guide-build-website.mdx
+++ b/website/content/en/blog/cases/qwencode-coding-plan-guide-build-website.mdx
@@ -4,7 +4,7 @@ date: "2026-03-06"
 description: "Use Qwen Code to quickly build personal websites, participate in open source projects, and generate demo videos. Practical guide for AI programming tools."
 author: "joeytoday"
 tags: ["Tutorials", "user examples", "coding plan"]
-image: https://gw.alicdn.com/imgextra/i2/O1CN01iO8dO31JWXTqKkKVS_!!6000000001036-2-tps-1344-572.png
+image: https://gw.alicdn.com/imgextra/i1/O1CN01bZiyqqomY7C2jBZY_!!6000000001569-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/en/blog/updates/weekly-update-2026-02-03.mdx
+++ b/website/content/en/blog/updates/weekly-update-2026-02-03.mdx
@@ -4,7 +4,7 @@ date: "2026-02-03"
 description: "This week we released v0.8.1, v0.8.2 stable versions and v0.9.0 preview, adding LSP support, batch-runner evaluation tool, unified UI architecture, and Japanese & Portuguese language support."
 author: "Qwen Team"
 tags: ["Product Updates", "release", "weekly"]
-image: https://gw.alicdn.com/imgextra/i1/O1CN01B6SOTZ1v4YgO9SuZF_!!6000000006119-0-tps-1344-576.jpg
+image: https://gw.alicdn.com/imgextra/i4/O1CN01KVv9hF1YZUGa64bnu_!!6000000003073-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/en/blog/updates/weekly-update-2026-03-20.mdx
+++ b/website/content/en/blog/updates/weekly-update-2026-03-20.mdx
@@ -4,7 +4,7 @@ date: "2026-03-20"
 description: "This week: Token limit increased from 8K to 16K, real-time token usage display, JetBrains/Zed editor integration, Plan Mode comparison view, plus Windows encoding fixes."
 author: "Qwen Team"
 tags: ["Product Updates", "release", "weekly"]
-image: https://gw.alicdn.com/imgextra/i4/O1CN012uBaHl1QC77z7o9ZL_!!6000000001939-0-tps-1344-576.jpg
+image: https://gw.alicdn.com/imgextra/i3/O1CN01lm0V1mqnS8D2jBZY_!!6000000002821-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/en/blog/updates/weekly-update-2026-05-07.mdx
+++ b/website/content/en/blog/updates/weekly-update-2026-05-07.mdx
@@ -4,7 +4,7 @@ date: "2026-05-07"
 description: "This week we released v0.15.7 and six follow-up releases, with DeepSeek V4 1M context support, a background task panel, conversation rewind, a stronger code review flow, task notifications, cost estimates, and faster model switching with `/model`."
 author: "Qwen Team"
 tags: ["Product Updates", "release", "weekly"]
-image: https://gw.alicdn.com/imgextra/i3/O1CN01VGy00z1RkIIlgXPNF_!!6000000002149-0-tps-1344-576.jpg
+image: https://gw.alicdn.com/imgextra/i2/O1CN01pbkzwbdftEG2jBZY_!!6000000001889-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/en/blog/updates/weekly-update-2026-06-11.mdx
+++ b/website/content/en/blog/updates/weekly-update-2026-06-11.mdx
@@ -4,7 +4,7 @@ date: "2026-06-11"
 description: "Qwen Code v0.18.0-preview launches /fork background agents, /skills visual skill management, user-level cross-project memory, plus Vim mode overhaul and standalone installer auto-update."
 author: "Qwen Team"
 tags: ["Product Updates", "release", "weekly"]
-image: https://gw.alicdn.com/imgextra/i3/O1CN01jhzdsD1cUgZmWj0JD_!!6000000003604-0-tps-1344-576.jpg
+image: https://gw.alicdn.com/imgextra/i3/O1CN01zBFsOx1vNKvC7sflf_!!6000000006160-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/en/blog/updates/weekly-update-2026-07-16.mdx
+++ b/website/content/en/blog/updates/weekly-update-2026-07-16.mdx
@@ -4,7 +4,7 @@ date: "2026-07-16"
 description: "This week we shipped v0.19.9, v0.19.10, and v0.19.11 — 3 stable releases with 160+ PRs merged. /learn command creates reusable Skills, Code Review verifier + reverse-audit, Web Shell shadcn overhaul + Artifact panel, Voice Bridge audio integration, automatic PDF-to-image fallback, CLI /update one-click upgrade."
 author: "Qwen Team"
 tags: ["Product Updates", "release", "weekly"]
-image: https://gw.alicdn.com/imgextra/i1/O1CN010k55XR1ZpnzarYSDW_!!6000000003244-0-tps-1344-576.jpg
+image: https://gw.alicdn.com/imgextra/i1/O1CN01rCacTOSznNB2jBZY_!!6000000002069-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/fr/blog/advanced/feat-skills-oss-styles.mdx
+++ b/website/content/fr/blog/advanced/feat-skills-oss-styles.mdx
@@ -4,7 +4,7 @@ date: "2026-03-18"
 description: "Présentation de la compétence oss-video de Qwen Code : il suffit de fournir une URL de dépôt GitHub pour générer automatiquement une vidéo promotionnelle de haute qualité pour votre projet open source"
 author: "joeytoday"
 tags: ["Tutoriels", "exemples d'utilisateurs", "Compétences", "Vidéo"]
-image: https://gw.alicdn.com/imgextra/i4/O1CN01EJM0M11lxqKk7Ct9b_!!6000000004886-2-tps-1344-572.png
+image: https://gw.alicdn.com/imgextra/i4/O1CN017qGRGZ1zEs41Gd6ue_!!6000000006683-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/fr/blog/advanced/qwencode-mpcover-skill-guide.mdx
+++ b/website/content/fr/blog/advanced/qwencode-mpcover-skill-guide.mdx
@@ -4,7 +4,7 @@ date: "2026-05-29"
 description: "Le plus pénible après avoir écrit un article, c'est de trouver une image de couverture. J'ai créé un Skill qui choisit automatiquement le style, génère les prompts et appelle Model Studio CLI pour créer des images. Voici les 4 styles et comment l'utiliser."
 author: "joeytoday"
 tags: ["Tutorials", "Skills", "Model Studio"]
-image: https://gw.alicdn.com/imgextra/i4/O1CN01Js6CsB1hMVaJFuk4K_!!6000000004263-0-tps-1344-572.jpg
+image: https://gw.alicdn.com/imgextra/i1/O1CN01ZSHWZb1pAcE5XMUAq_!!6000000005320-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/fr/blog/cases/obsidian.mdx
+++ b/website/content/fr/blog/cases/obsidian.mdx
@@ -4,7 +4,7 @@ date: "2026-03-16"
 description: "Intégrez Qwen Code dans Obsidian pour améliorer l'efficacité de la gestion des connaissances grâce à l'installation de plugins, la configuration de l'authentification et des capacités multimodales telles que la polish d'écriture, la génération d'images et le web scraping."
 author: "pomelo-nwu"
 tags: ["Tutoriels", "Exemples d'utilisateurs"]
-image: https://gw.alicdn.com/imgextra/i2/O1CN01PXEOUq23HOiC2jYkT_!!6000000007230-2-tps-1344-572.png
+image: https://gw.alicdn.com/imgextra/i4/O1CN01lpXwKE24vzQld9Tnc_!!6000000007454-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/fr/blog/cases/qwencode-coding-plan-guide-build-website.mdx
+++ b/website/content/fr/blog/cases/qwencode-coding-plan-guide-build-website.mdx
@@ -4,7 +4,7 @@ date: "2026-03-06"
 description: "Utilisez Qwen Code pour créer rapidement des sites personnels, participer à des projets open source et générer des vidéos de démonstration. Guide pratique pour les outils de programmation IA."
 author: "joeytoday"
 tags: ["Tutoriels", "exemples utilisateur", "plan de codage"]
-image: https://gw.alicdn.com/imgextra/i2/O1CN01iO8dO31JWXTqKkKVS_!!6000000001036-2-tps-1344-572.png
+image: https://gw.alicdn.com/imgextra/i1/O1CN01bZiyqqomY7C2jBZY_!!6000000001569-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/fr/blog/updates/weekly-update-2026-02-03.mdx
+++ b/website/content/fr/blog/updates/weekly-update-2026-02-03.mdx
@@ -4,7 +4,7 @@ date: "2026-02-03"
 description: "Cette semaine, nous avons publié les versions stables v0.8.1, v0.8.2 et la préversion v0.9.0, ajoutant le support LSP, l'outil d'évaluation batch-runner, l'architecture UI unifiée et le support des langues japonaise et portugaise."
 author: "Qwen Team"
 tags: ["Product Updates", "release", "weekly"]
-image: https://gw.alicdn.com/imgextra/i1/O1CN01B6SOTZ1v4YgO9SuZF_!!6000000006119-0-tps-1344-576.jpg
+image: https://gw.alicdn.com/imgextra/i4/O1CN01KVv9hF1YZUGa64bnu_!!6000000003073-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/fr/blog/updates/weekly-update-2026-03-20.mdx
+++ b/website/content/fr/blog/updates/weekly-update-2026-03-20.mdx
@@ -4,7 +4,7 @@ date: "2026-03-20"
 description: "Cette semaine : Limite de tokens de 8K à 16K, affichage en temps réel de la consommation, intégration JetBrains/Zed, vue de comparaison Plan Mode, plus correctifs d'encodage Windows."
 author: "Qwen Team"
 tags: ["Mises à jour Produit", "release", "hebdomadaire"]
-image: https://gw.alicdn.com/imgextra/i4/O1CN012uBaHl1QC77z7o9ZL_!!6000000001939-0-tps-1344-576.jpg
+image: https://gw.alicdn.com/imgextra/i3/O1CN01lm0V1mqnS8D2jBZY_!!6000000002821-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/fr/blog/updates/weekly-update-2026-05-07.mdx
+++ b/website/content/fr/blog/updates/weekly-update-2026-05-07.mdx
@@ -4,7 +4,7 @@ date: "2026-05-07"
 description: "Cette semaine, nous avons publié v0.15.7 et six mises à jour intermédiaires, avec DeepSeek V4 et son contexte 1M, un panneau de tâches en arrière-plan, le retour en arrière dans une conversation, un flux de code review amélioré, des notifications de tâches, l'estimation des coûts et le changement rapide de modèle avec `/model`."
 author: "Qwen Team"
 tags: ["Product Updates", "release", "weekly"]
-image: https://gw.alicdn.com/imgextra/i3/O1CN01VGy00z1RkIIlgXPNF_!!6000000002149-0-tps-1344-576.jpg
+image: https://gw.alicdn.com/imgextra/i2/O1CN01pbkzwbdftEG2jBZY_!!6000000001889-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/fr/blog/updates/weekly-update-2026-06-11.mdx
+++ b/website/content/fr/blog/updates/weekly-update-2026-06-11.mdx
@@ -4,7 +4,7 @@ date: "2026-06-11"
 description: "Qwen Code v0.18.0-preview lance les agents arrière-plan /fork, la gestion visuelle des skills /skills, la mémoire utilisateur inter-projets, plus refonte du mode Vim et mise à jour automatique de l'installateur autonome."
 author: "Qwen Team"
 tags: ["Product Updates", "release", "weekly"]
-image: https://gw.alicdn.com/imgextra/i3/O1CN01jhzdsD1cUgZmWj0JD_!!6000000003604-0-tps-1344-576.jpg
+image: https://gw.alicdn.com/imgextra/i3/O1CN01zBFsOx1vNKvC7sflf_!!6000000006160-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/fr/blog/updates/weekly-update-2026-07-16.mdx
+++ b/website/content/fr/blog/updates/weekly-update-2026-07-16.mdx
@@ -4,7 +4,7 @@ date: "2026-07-16"
 description: "Trois versions stables cette semaine (v0.19.9 à v0.19.11), 160+ PR fusionnés. Commande /learn pour créer des Skills réutilisables, Code Review avec verifier et reverse-audit, Web Shell repensé avec shadcn et panneau Artifact, Voice Bridge pour l'entrée vocale, conversion PDF en image, mise à jour en un clic via /update."
 author: "Qwen Team"
 tags: ["Product Updates", "release", "weekly"]
-image: https://gw.alicdn.com/imgextra/i1/O1CN010k55XR1ZpnzarYSDW_!!6000000003244-0-tps-1344-576.jpg
+image: https://gw.alicdn.com/imgextra/i1/O1CN01rCacTOSznNB2jBZY_!!6000000002069-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/ja/blog/advanced/feat-skills-oss-styles.mdx
+++ b/website/content/ja/blog/advanced/feat-skills-oss-styles.mdx
@@ -4,7 +4,7 @@ date: "2026-03-18"
 description: "Qwen Code の oss-video スキルのご紹介。GitHub リポジトリの URL を入力するだけで、オープンソースプロジェクトの高品質なプロモーションビデオを自動生成します"
 author: "joeytoday"
 tags: ["チュートリアル", "ユーザー事例", "スキル", "ビデオ"]
-image: https://gw.alicdn.com/imgextra/i4/O1CN01EJM0M11lxqKk7Ct9b_!!6000000004886-2-tps-1344-572.png
+image: https://gw.alicdn.com/imgextra/i4/O1CN017qGRGZ1zEs41Gd6ue_!!6000000006683-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/ja/blog/advanced/qwencode-mpcover-skill-guide.mdx
+++ b/website/content/ja/blog/advanced/qwencode-mpcover-skill-guide.mdx
@@ -4,7 +4,7 @@ date: "2026-05-29"
 description: "記事を書き終わった後、一番面倒なのがカバー画像探し。記事の内容に基づいて自動でスタイルを選び、プロンプトを生成し、Model Studio CLIで画像を作るSkillを作りました。4つのスタイルと使い方を紹介します。"
 author: "joeytoday"
 tags: ["Tutorials", "Skills", "Model Studio"]
-image: https://gw.alicdn.com/imgextra/i4/O1CN01Js6CsB1hMVaJFuk4K_!!6000000004263-0-tps-1344-572.jpg
+image: https://gw.alicdn.com/imgextra/i1/O1CN01ZSHWZb1pAcE5XMUAq_!!6000000005320-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/ja/blog/cases/obsidian.mdx
+++ b/website/content/ja/blog/cases/obsidian.mdx
@@ -4,7 +4,7 @@ date: "2026-03-16"
 description: "プラグインのインストール、認証設定、および文章の推敲、画像生成、ウェブスクレイピングなどのマルチモーダル機能を通じて、Qwen Code を Obsidian に統合し、ナレッジマネジメントの効率を向上させます。"
 author: "pomelo-nwu"
 tags: ["チュートリアル", "ユーザー事例"]
-image: https://gw.alicdn.com/imgextra/i2/O1CN01PXEOUq23HOiC2jYkT_!!6000000007230-2-tps-1344-572.png
+image: https://gw.alicdn.com/imgextra/i4/O1CN01lpXwKE24vzQld9Tnc_!!6000000007454-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/ja/blog/cases/qwencode-coding-plan-guide-build-website.mdx
+++ b/website/content/ja/blog/cases/qwencode-coding-plan-guide-build-website.mdx
@@ -4,7 +4,7 @@ date: "2026-03-06"
 description: "Qwen Codeを使って個人サイト構築、オープンソース参加、デモ動画制作を素早く行う。AIプログラミングツール実践ガイド。"
 author: "joeytoday"
 tags: ["Tutorials", "user examples", "coding plan"]
-image: https://gw.alicdn.com/imgextra/i2/O1CN01iO8dO31JWXTqKkKVS_!!6000000001036-2-tps-1344-572.png
+image: https://gw.alicdn.com/imgextra/i1/O1CN01bZiyqqomY7C2jBZY_!!6000000001569-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/ja/blog/updates/weekly-update-2026-02-03.mdx
+++ b/website/content/ja/blog/updates/weekly-update-2026-02-03.mdx
@@ -4,7 +4,7 @@ date: "2026-02-03"
 description: "今週はv0.8.1、v0.8.2安定版とv0.9.0プレビュー版をリリースし、LSPサポート、batch-runner評価ツール、統一UIアーキテクチャ、および日本語・ポルトガル語対応を追加しました。"
 author: "Qwen Team"
 tags: ["Product Updates", "release", "weekly"]
-image: https://gw.alicdn.com/imgextra/i1/O1CN01B6SOTZ1v4YgO9SuZF_!!6000000006119-0-tps-1344-576.jpg
+image: https://gw.alicdn.com/imgextra/i4/O1CN01KVv9hF1YZUGa64bnu_!!6000000003073-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/ja/blog/updates/weekly-update-2026-03-20.mdx
+++ b/website/content/ja/blog/updates/weekly-update-2026-03-20.mdx
@@ -4,7 +4,7 @@ date: "2026-03-20"
 description: "今週のアップデート：トークン制限を8Kから16Kに増量、リアルタイムトークン消費表示、JetBrains/Zed エディタ統合、Plan Mode の比較表示、Windows エンコーディング問題の修正。"
 author: "Qwen Team"
 tags: ["製品アップデート", "release", "週報"]
-image: https://gw.alicdn.com/imgextra/i4/O1CN012uBaHl1QC77z7o9ZL_!!6000000001939-0-tps-1344-576.jpg
+image: https://gw.alicdn.com/imgextra/i3/O1CN01lm0V1mqnS8D2jBZY_!!6000000002821-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/ja/blog/updates/weekly-update-2026-05-07.mdx
+++ b/website/content/ja/blog/updates/weekly-update-2026-05-07.mdx
@@ -4,7 +4,7 @@ date: "2026-05-07"
 description: "今週は v0.15.7 と 6 つの更新版をリリースしました。DeepSeek V4 の 100 万コンテキスト、バックグラウンドタスクパネル、会話の巻き戻し、コードレビュー改善、タスク通知、費用見積もり、`/model` による素早いモデル切り替えを追加しています。"
 author: "Qwen Team"
 tags: ["Product Updates", "release", "weekly"]
-image: https://gw.alicdn.com/imgextra/i3/O1CN01VGy00z1RkIIlgXPNF_!!6000000002149-0-tps-1344-576.jpg
+image: https://gw.alicdn.com/imgextra/i2/O1CN01pbkzwbdftEG2jBZY_!!6000000001889-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/ja/blog/updates/weekly-update-2026-06-11.mdx
+++ b/website/content/ja/blog/updates/weekly-update-2026-06-11.mdx
@@ -4,7 +4,7 @@ date: "2026-06-11"
 description: "Qwen Code v0.18.0-preview は /fork バックグラウンドエージェント、/skills 可視化スキル管理、ユーザーレベルのクロスプロジェクトメモリ、Vim モード大修繕、スタンドアロンインストーラー自動更新を搭載。"
 author: "Qwen Team"
 tags: ["Product Updates", "release", "weekly"]
-image: https://gw.alicdn.com/imgextra/i3/O1CN01jhzdsD1cUgZmWj0JD_!!6000000003604-0-tps-1344-576.jpg
+image: https://gw.alicdn.com/imgextra/i3/O1CN01zBFsOx1vNKvC7sflf_!!6000000006160-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/ja/blog/updates/weekly-update-2026-07-16.mdx
+++ b/website/content/ja/blog/updates/weekly-update-2026-07-16.mdx
@@ -4,7 +4,7 @@ date: "2026-07-16"
 description: "今週は v0.19.9、v0.19.10、v0.19.11 の 3 つの正式版をリリース、160 以上の PR をマージ。/learn コマンドで再利用可能な Skill を作成、Code Review に verifier と reverse-audit を追加、Web Shell を shadcn ベースで刷新し Artifact パネルを追加、Voice Bridge 音声入力対応、PDF 自動画像変換、CLI /update でワンクリックアップグレード。"
 author: "Qwen Team"
 tags: ["Product Updates", "release", "weekly"]
-image: https://gw.alicdn.com/imgextra/i1/O1CN010k55XR1ZpnzarYSDW_!!6000000003244-0-tps-1344-576.jpg
+image: https://gw.alicdn.com/imgextra/i1/O1CN01rCacTOSznNB2jBZY_!!6000000002069-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/pt-BR/blog/advanced/feat-skills-oss-styles.mdx
+++ b/website/content/pt-BR/blog/advanced/feat-skills-oss-styles.mdx
@@ -4,7 +4,7 @@ date: "2026-03-18"
 description: "Apresentando a habilidade oss-video do Qwen Code: basta fornecer uma URL de repositório do GitHub para gerar automaticamente um vídeo promocional de alta qualidade para seu projeto open source"
 author: "joeytoday"
 tags: ["Tutoriais", "exemplos de usuários", "Habilidades", "Vídeo"]
-image: https://gw.alicdn.com/imgextra/i4/O1CN01EJM0M11lxqKk7Ct9b_!!6000000004886-2-tps-1344-572.png
+image: https://gw.alicdn.com/imgextra/i4/O1CN017qGRGZ1zEs41Gd6ue_!!6000000006683-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/pt-BR/blog/advanced/qwencode-mpcover-skill-guide.mdx
+++ b/website/content/pt-BR/blog/advanced/qwencode-mpcover-skill-guide.mdx
@@ -4,7 +4,7 @@ date: "2026-05-29"
 description: "A parte mais chata depois de escrever um artigo é encontrar a imagem de capa. Criei um Skill que escolhe automaticamente o estilo, gera prompts e chama o Model Studio CLI para criar imagens baseadas no conteúdo do artigo. Aqui estão os 4 estilos e como usar."
 author: "joeytoday"
 tags: ["Tutorials", "Skills", "Model Studio"]
-image: https://gw.alicdn.com/imgextra/i4/O1CN01Js6CsB1hMVaJFuk4K_!!6000000004263-0-tps-1344-572.jpg
+image: https://gw.alicdn.com/imgextra/i1/O1CN01ZSHWZb1pAcE5XMUAq_!!6000000005320-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/pt-BR/blog/cases/obsidian.mdx
+++ b/website/content/pt-BR/blog/cases/obsidian.mdx
@@ -4,7 +4,7 @@ date: "2026-03-16"
 description: "Integre o Qwen Code ao Obsidian para melhorar a eficiência do gerenciamento de conhecimento através da instalação de plugins, configuração de autenticação e capacidades multimodais como polimento de escrita, geração de imagens e web scraping."
 author: "pomelo-nwu"
 tags: ["Tutoriais", "Exemplos de usuários"]
-image: https://gw.alicdn.com/imgextra/i2/O1CN01PXEOUq23HOiC2jYkT_!!6000000007230-2-tps-1344-572.png
+image: https://gw.alicdn.com/imgextra/i4/O1CN01lpXwKE24vzQld9Tnc_!!6000000007454-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/pt-BR/blog/cases/qwencode-coding-plan-guide-build-website.mdx
+++ b/website/content/pt-BR/blog/cases/qwencode-coding-plan-guide-build-website.mdx
@@ -4,7 +4,7 @@ date: "2026-03-06"
 description: "Use o Qwen Code para criar rapidamente sites pessoais, participar de projetos open source e gerar vídeos demonstrativos. Guia prático para ferramentas de programação por IA."
 author: "joeytoday"
 tags: ["Tutoriais", "exemplos de usuários", "plano de codificação"]
-image: https://gw.alicdn.com/imgextra/i2/O1CN01iO8dO31JWXTqKkKVS_!!6000000001036-2-tps-1344-572.png
+image: https://gw.alicdn.com/imgextra/i1/O1CN01bZiyqqomY7C2jBZY_!!6000000001569-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/pt-BR/blog/updates/weekly-update-2026-02-03.mdx
+++ b/website/content/pt-BR/blog/updates/weekly-update-2026-02-03.mdx
@@ -4,7 +4,7 @@ date: "2026-02-03"
 description: "Esta semana lançamos as versões estáveis v0.8.1, v0.8.2 e a prévia v0.9.0, adicionando suporte LSP, ferramenta de avaliação batch-runner, arquitetura UI unificada e suporte aos idiomas japonês e português."
 author: "Qwen Team"
 tags: ["Product Updates", "release", "weekly"]
-image: https://gw.alicdn.com/imgextra/i1/O1CN01B6SOTZ1v4YgO9SuZF_!!6000000006119-0-tps-1344-576.jpg
+image: https://gw.alicdn.com/imgextra/i4/O1CN01KVv9hF1YZUGa64bnu_!!6000000003073-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/pt-BR/blog/updates/weekly-update-2026-03-20.mdx
+++ b/website/content/pt-BR/blog/updates/weekly-update-2026-03-20.mdx
@@ -4,7 +4,7 @@ date: "2026-03-20"
 description: "Esta semana: Limite de tokens aumentado de 8K para 16K, exibição de consumo em tempo real, integração JetBrains/Zed, visualização de comparação no Plan Mode, além de correções de codificação no Windows."
 author: "Qwen Team"
 tags: ["Atualizações do Produto", "release", "semanal"]
-image: https://gw.alicdn.com/imgextra/i4/O1CN012uBaHl1QC77z7o9ZL_!!6000000001939-0-tps-1344-576.jpg
+image: https://gw.alicdn.com/imgextra/i3/O1CN01lm0V1mqnS8D2jBZY_!!6000000002821-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/pt-BR/blog/updates/weekly-update-2026-05-07.mdx
+++ b/website/content/pt-BR/blog/updates/weekly-update-2026-05-07.mdx
@@ -4,7 +4,7 @@ date: "2026-05-07"
 description: "Nesta semana lançamos a v0.15.7 e seis versões incrementais, com suporte ao DeepSeek V4 com contexto de 1M, painel de tarefas em segundo plano, rewind de conversa, revisão de código melhorada, notificações de tarefas, estimativa de custos e troca rápida de modelo com `/model`."
 author: "Qwen Team"
 tags: ["Product Updates", "release", "weekly"]
-image: https://gw.alicdn.com/imgextra/i3/O1CN01VGy00z1RkIIlgXPNF_!!6000000002149-0-tps-1344-576.jpg
+image: https://gw.alicdn.com/imgextra/i2/O1CN01pbkzwbdftEG2jBZY_!!6000000001889-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/pt-BR/blog/updates/weekly-update-2026-06-11.mdx
+++ b/website/content/pt-BR/blog/updates/weekly-update-2026-06-11.mdx
@@ -4,7 +4,7 @@ date: "2026-06-11"
 description: "Qwen Code v0.18.0-preview lança agentes em segundo plano /fork, gerenciamento visual de skills /skills, memória cross-projeto em nível de usuário, além de reformulação do modo Vim e atualização automática do instalador standalone."
 author: "Qwen Team"
 tags: ["Product Updates", "release", "weekly"]
-image: https://gw.alicdn.com/imgextra/i3/O1CN01jhzdsD1cUgZmWj0JD_!!6000000003604-0-tps-1344-576.jpg
+image: https://gw.alicdn.com/imgextra/i3/O1CN01zBFsOx1vNKvC7sflf_!!6000000006160-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/pt-BR/blog/updates/weekly-update-2026-07-16.mdx
+++ b/website/content/pt-BR/blog/updates/weekly-update-2026-07-16.mdx
@@ -4,7 +4,7 @@ date: "2026-07-16"
 description: "Três versões oficiais esta semana (v0.19.9, v0.19.10, v0.19.11), com 160+ PRs integrados. Comando /learn cria Skills reutilizáveis, Code Review ganha verifier e reverse-audit, Web Shell renova com shadcn e painel Artifact, Voice Bridge para entrada de voz, conversão automática de PDF para imagem, /update para atualização com um clique."
 author: "Qwen Team"
 tags: ["Product Updates", "release", "weekly"]
-image: https://gw.alicdn.com/imgextra/i1/O1CN010k55XR1ZpnzarYSDW_!!6000000003244-0-tps-1344-576.jpg
+image: https://gw.alicdn.com/imgextra/i1/O1CN01rCacTOSznNB2jBZY_!!6000000002069-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/ru/blog/advanced/feat-skills-oss-styles.mdx
+++ b/website/content/ru/blog/advanced/feat-skills-oss-styles.mdx
@@ -4,7 +4,7 @@ date: "2026-03-18"
 description: "Знакомство с навыком oss-video от Qwen Code: просто укажите URL репозитория GitHub, и он автоматически сгенерирует высококачественное промо-видео для вашего open source проекта"
 author: "joeytoday"
 tags: ["Уроки", "примеры пользователей", "Навыки", "Видео"]
-image: https://gw.alicdn.com/imgextra/i4/O1CN01EJM0M11lxqKk7Ct9b_!!6000000004886-2-tps-1344-572.png
+image: https://gw.alicdn.com/imgextra/i4/O1CN017qGRGZ1zEs41Gd6ue_!!6000000006683-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/ru/blog/advanced/qwencode-mpcover-skill-guide.mdx
+++ b/website/content/ru/blog/advanced/qwencode-mpcover-skill-guide.mdx
@@ -4,7 +4,7 @@ date: "2026-05-29"
 description: "Самое раздражающее после написания статьи — поиск обложки. Я создал Skill, который автоматически выбирает стиль, генерирует промпты и вызывает Model Studio CLI для создания изображений на основе содержания статьи. Вот 4 стиля и инструкция по использованию."
 author: "joeytoday"
 tags: ["Tutorials", "Skills", "Model Studio"]
-image: https://gw.alicdn.com/imgextra/i4/O1CN01Js6CsB1hMVaJFuk4K_!!6000000004263-0-tps-1344-572.jpg
+image: https://gw.alicdn.com/imgextra/i1/O1CN01ZSHWZb1pAcE5XMUAq_!!6000000005320-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/ru/blog/cases/obsidian.mdx
+++ b/website/content/ru/blog/cases/obsidian.mdx
@@ -4,7 +4,7 @@ date: "2026-03-16"
 description: "Интегрируйте Qwen Code в Obsidian для повышения эффективности управления знаниями через установку плагинов, настройку аутентификации и мультимодальные возможности, такие как полировка текста, генерация изображений и веб-скрейпинг."
 author: "pomelo-nwu"
 tags: ["Учебные пособия", "Примеры пользователей"]
-image: https://gw.alicdn.com/imgextra/i2/O1CN01PXEOUq23HOiC2jYkT_!!6000000007230-2-tps-1344-572.png
+image: https://gw.alicdn.com/imgextra/i4/O1CN01lpXwKE24vzQld9Tnc_!!6000000007454-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/ru/blog/cases/qwencode-coding-plan-guide-build-website.mdx
+++ b/website/content/ru/blog/cases/qwencode-coding-plan-guide-build-website.mdx
@@ -4,7 +4,7 @@ date: "2026-03-06"
 description: "Быстро создавайте личные сайты, участвуйте в опенсорс-проектах и генерируйте демо-видео с помощью Qwen Code. Практическое руководство по инструментам ИИ-программирования."
 author: "joeytoday"
 tags: ["Уроки", "примеры пользователей", "план программирования"]
-image: https://gw.alicdn.com/imgextra/i2/O1CN01iO8dO31JWXTqKkKVS_!!6000000001036-2-tps-1344-572.png
+image: https://gw.alicdn.com/imgextra/i1/O1CN01bZiyqqomY7C2jBZY_!!6000000001569-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/ru/blog/updates/weekly-update-2026-02-03.mdx
+++ b/website/content/ru/blog/updates/weekly-update-2026-02-03.mdx
@@ -4,7 +4,7 @@ date: "2026-02-03"
 description: "На этой неделе мы выпустили стабильные версии v0.8.1, v0.8.2 и предварительную версию v0.9.0, добавив поддержку LSP, инструмент оценки batch-runner, унифицированную архитектуру UI и поддержку японского и португальского языков."
 author: "Qwen Team"
 tags: ["Product Updates", "release", "weekly"]
-image: https://gw.alicdn.com/imgextra/i1/O1CN01B6SOTZ1v4YgO9SuZF_!!6000000006119-0-tps-1344-576.jpg
+image: https://gw.alicdn.com/imgextra/i4/O1CN01KVv9hF1YZUGa64bnu_!!6000000003073-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/ru/blog/updates/weekly-update-2026-03-20.mdx
+++ b/website/content/ru/blog/updates/weekly-update-2026-03-20.mdx
@@ -4,7 +4,7 @@ date: "2026-03-20"
 description: "На этой неделе: Лимит токенов увеличен с 8K до 16K, отображение потребления в реальном времени, интеграция JetBrains/Zed, сравнение в Plan Mode, а также исправления кодировки Windows."
 author: "Qwen Team"
 tags: ["Обновления продукта", "release", "еженедельно"]
-image: https://gw.alicdn.com/imgextra/i4/O1CN012uBaHl1QC77z7o9ZL_!!6000000001939-0-tps-1344-576.jpg
+image: https://gw.alicdn.com/imgextra/i3/O1CN01lm0V1mqnS8D2jBZY_!!6000000002821-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/ru/blog/updates/weekly-update-2026-05-07.mdx
+++ b/website/content/ru/blog/updates/weekly-update-2026-05-07.mdx
@@ -4,7 +4,7 @@ date: "2026-05-07"
 description: "На этой неделе вышли v0.15.7 и шесть промежуточных релизов: поддержка DeepSeek V4 с контекстом 1M, панель фоновых задач, откат диалога, обновленный code review, уведомления о задачах, оценка стоимости и быстрое переключение модели через `/model`."
 author: "Qwen Team"
 tags: ["Product Updates", "release", "weekly"]
-image: https://gw.alicdn.com/imgextra/i3/O1CN01VGy00z1RkIIlgXPNF_!!6000000002149-0-tps-1344-576.jpg
+image: https://gw.alicdn.com/imgextra/i2/O1CN01pbkzwbdftEG2jBZY_!!6000000001889-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/ru/blog/updates/weekly-update-2026-06-11.mdx
+++ b/website/content/ru/blog/updates/weekly-update-2026-06-11.mdx
@@ -4,7 +4,7 @@ date: "2026-06-11"
 description: "Qwen Code v0.18.0-preview запускает фоновые агенты /fork, визуальное управление навыками /skills, пользовательскую межпроектную память, а также переработку режима Vim и автообновление автономного установщика."
 author: "Qwen Team"
 tags: ["Product Updates", "release", "weekly"]
-image: https://gw.alicdn.com/imgextra/i3/O1CN01jhzdsD1cUgZmWj0JD_!!6000000003604-0-tps-1344-576.jpg
+image: https://gw.alicdn.com/imgextra/i3/O1CN01zBFsOx1vNKvC7sflf_!!6000000006160-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/ru/blog/updates/weekly-update-2026-07-16.mdx
+++ b/website/content/ru/blog/updates/weekly-update-2026-07-16.mdx
@@ -4,7 +4,7 @@ date: "2026-07-16"
 description: "На этой неделе выпущены 3 стабильные версии v0.19.9–v0.19.11, принято более 160 PR. Команда /learn для создания переиспользуемых Skill, Code Review с verifier и reverse-audit, Web Shell на shadcn + панель Artifact, Voice Bridge для голосового ввода, автоконвертация PDF в изображения, /update для обновления в один клик."
 author: "Qwen Team"
 tags: ["Product Updates", "release", "weekly"]
-image: https://gw.alicdn.com/imgextra/i1/O1CN010k55XR1ZpnzarYSDW_!!6000000003244-0-tps-1344-576.jpg
+image: https://gw.alicdn.com/imgextra/i1/O1CN01rCacTOSznNB2jBZY_!!6000000002069-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/zh/blog/advanced/feat-skills-oss-styles.mdx
+++ b/website/content/zh/blog/advanced/feat-skills-oss-styles.mdx
@@ -4,7 +4,7 @@ date: "2026-03-18"
 description: "介绍 Qwen Code 的 oss-video 技能，只需传入 GitHub 仓库地址，就能自动生成高质量的开源项目宣传视频"
 author: "joeytoday"
 tags: ["Tutorials", "user examples","Skills", "Video"]
-image: https://gw.alicdn.com/imgextra/i4/O1CN01EJM0M11lxqKk7Ct9b_!!6000000004886-2-tps-1344-572.png
+image: https://gw.alicdn.com/imgextra/i4/O1CN017qGRGZ1zEs41Gd6ue_!!6000000006683-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/zh/blog/advanced/qwencode-mpcover-skill-guide.mdx
+++ b/website/content/zh/blog/advanced/qwencode-mpcover-skill-guide.mdx
@@ -4,7 +4,7 @@ date: "2026-05-29"
 description: "每次写完文章最头疼的就是找封面图。我做了一个 Skill，根据文章内容自动选风格、出提示词、调百炼 CLI 生图。附4种风格效果和使用方法。"
 author: "joeytoday"
 tags: ["Tutorials", "Skills", "Model Studio"]
-image: https://gw.alicdn.com/imgextra/i4/O1CN01Js6CsB1hMVaJFuk4K_!!6000000004263-0-tps-1344-572.jpg
+image: https://gw.alicdn.com/imgextra/i1/O1CN01ZSHWZb1pAcE5XMUAq_!!6000000005320-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/zh/blog/cases/obsidian.mdx
+++ b/website/content/zh/blog/cases/obsidian.mdx
@@ -4,7 +4,7 @@ date: "2026-03-16"
 description: "Qwen Code 集成到 Obsidian 中，通过安装插件、配置认证、调用多模态能力（如写作润色、生图、网页抓取）提升知识管理效率。"
 author: "pomelo-nwu"
 tags: ["Tutorials", "user examples"]
-image: https://gw.alicdn.com/imgextra/i2/O1CN01PXEOUq23HOiC2jYkT_!!6000000007230-2-tps-1344-572.png
+image: https://gw.alicdn.com/imgextra/i4/O1CN01lpXwKE24vzQld9Tnc_!!6000000007454-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/zh/blog/cases/qwencode-coding-plan-guide-build-website.mdx
+++ b/website/content/zh/blog/cases/qwencode-coding-plan-guide-build-website.mdx
@@ -4,7 +4,7 @@ date: "2026-03-06"
 description: "Qwen Code + Coding Plan 实践指南：10 分钟搭建个人网站、参与开源项目并生成演示视频，适合学生和开发者完成作品集、课程作业与 AI 编程实战。查看完整视频演示，学习提示词设计、文件上下文注入、工具调用和结果落地的操作步骤，适合新手快速复现并应用到真实项目。同时补充常见痛点和复现建议。"
 author: "joeytoday"
 tags: ["Tutorials", "user examples", "coding plan"]
-image: https://gw.alicdn.com/imgextra/i2/O1CN01iO8dO31JWXTqKkKVS_!!6000000001036-2-tps-1344-572.png
+image: https://gw.alicdn.com/imgextra/i1/O1CN01bZiyqqomY7C2jBZY_!!6000000001569-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/zh/blog/updates/weekly-update-2026-02-03.mdx
+++ b/website/content/zh/blog/updates/weekly-update-2026-02-03.mdx
@@ -4,7 +4,7 @@ date: "2026-02-03"
 description: "本周发布 v0.8.1、v0.8.2 正式版和 v0.9.0 预览版，新增 LSP 支持、batch-runner 批量评测工具、统一 UI 架构，以及日语和葡萄牙语支持。"
 author: "Qwen Team"
 tags: ["Product Updates", "release", "weekly"]
-image: https://gw.alicdn.com/imgextra/i1/O1CN01B6SOTZ1v4YgO9SuZF_!!6000000006119-0-tps-1344-576.jpg
+image: https://gw.alicdn.com/imgextra/i4/O1CN01KVv9hF1YZUGa64bnu_!!6000000003073-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/zh/blog/updates/weekly-update-2026-03-20.mdx
+++ b/website/content/zh/blog/updates/weekly-update-2026-03-20.mdx
@@ -4,7 +4,7 @@ date: "2026-03-20"
 description: "本周新增 Token 限制从 8K 提升到 16K、实时显示 Token 消耗、JetBrains/Zed 编辑器集成、Plan Mode 方案对比，还有 Windows 编码问题修复。"
 author: "Qwen Team"
 tags: ["Product Updates", "release", "weekly"]
-image: https://gw.alicdn.com/imgextra/i4/O1CN012uBaHl1QC77z7o9ZL_!!6000000001939-0-tps-1344-576.jpg
+image: https://gw.alicdn.com/imgextra/i3/O1CN01lm0V1mqnS8D2jBZY_!!6000000002821-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/zh/blog/updates/weekly-update-2026-05-07.mdx
+++ b/website/content/zh/blog/updates/weekly-update-2026-05-07.mdx
@@ -4,7 +4,7 @@ date: "2026-05-07"
 description: "本周发布 v0.15.7 和 6 个迭代版本，新增 DeepSeek V4 百万上下文、后台任务面板、对话回退、代码审查升级、任务通知、费用预估和 `/model` 快速切换模型等能力。"
 author: "Qwen Team"
 tags: ["Product Updates", "release", "weekly"]
-image: https://gw.alicdn.com/imgextra/i3/O1CN01VGy00z1RkIIlgXPNF_!!6000000002149-0-tps-1344-576.jpg
+image: https://gw.alicdn.com/imgextra/i2/O1CN01pbkzwbdftEG2jBZY_!!6000000001889-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/zh/blog/updates/weekly-update-2026-06-11.mdx
+++ b/website/content/zh/blog/updates/weekly-update-2026-06-11.mdx
@@ -4,7 +4,7 @@ date: "2026-06-11"
 description: "Qwen Code v0.18.0-preview 本周上线 /fork 后台 Agent、/skills 可视化技能管理、用户级跨项目记忆，同时 Vim 模式大修、独立安装支持自动更新。"
 author: "Qwen Team"
 tags: ["Product Updates", "release", "weekly"]
-image: https://gw.alicdn.com/imgextra/i3/O1CN01jhzdsD1cUgZmWj0JD_!!6000000003604-0-tps-1344-576.jpg
+image: https://gw.alicdn.com/imgextra/i3/O1CN01zBFsOx1vNKvC7sflf_!!6000000006160-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/zh/blog/updates/weekly-update-2026-07-16.mdx
+++ b/website/content/zh/blog/updates/weekly-update-2026-07-16.mdx
@@ -4,7 +4,7 @@ date: "2026-07-16"
 description: "本周发布 v0.19.9、v0.19.10、v0.19.11 三个正式版本，160+ 个 PR 合入。/learn 命令创建可复用 Skill、Code Review verifier + reverse-audit、Web Shell shadcn 翻新 + Artifact 面板、Voice Bridge 语音接入、PDF 自动转图片、CLI /update 一键升级。"
 author: "Qwen Team"
 tags: ["Product Updates", "release", "weekly"]
-image: https://gw.alicdn.com/imgextra/i1/O1CN010k55XR1ZpnzarYSDW_!!6000000003244-0-tps-1344-576.jpg
+image: https://gw.alicdn.com/imgextra/i1/O1CN01rCacTOSznNB2jBZY_!!6000000002069-0-tps-1344-576.jpg
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'


### PR DESCRIPTION
## 改了什么

刷新 9 篇文章的封面（每篇 × 7 语言，共 63 个文件），换成更贴文章内容的新封面。

### 常青文章（4 篇，微距实物，按内容重新选物）

| 文章 | 新封面 |
|------|--------|
| obsidian（知识管理） | 牛皮纸 · 牛皮棕 |
| qwencode-mpcover-skill-guide（封面生成技能） | 釉面陶瓷 · 玫瑰粉 |
| feat-skills-oss-styles（电影级宣传片） | 玻璃镜头+金属 · 深靛蓝 |
| qwencode-coding-plan-guide-build-website（学生作业/作品集） | 黑板 · 黑板绿 |

### 周报（5 期，晕染，重做为非径向构图）

0203 / 0320 / 0507 / 0611 / 0716 五期原为径向构图，会出花形，重做为非径向构图并加禁花负面词：

- 0203 紫 · 垂直沉降
- 0320 青绿 · 横向水痕
- 0507 靛蓝 · 有机流体
- 0611 蜜桃 · 对角
- 0716 珊瑚 · 横向水痕

## 预览

<!-- obsidian -->
before | after
-- | --
<img width="1483" height="1118" alt="image" src="https://github.com/user-attachments/assets/c18d5509-436e-49c7-a017-f61e78cdaba7" />  |  <img width="1460" height="778" alt="image" src="https://github.com/user-attachments/assets/643cce2d-884a-46a2-a017-cef26708471b" />
<img width="1399" height="1165" alt="image" src="https://github.com/user-attachments/assets/d1b84475-c0c8-4c6e-930b-ab8a6361facf" /> |  <img width="1399" height="1165" alt="image" src="https://github.com/user-attachments/assets/33d55fcd-12d6-4049-82d0-ff25b78c0689" />


