### PR TITLE
ci: make OPENAI_BASE_URL configurable via repo variable

### DIFF
--- a/.github/workflows/daily-translate.yml
+++ b/.github/workflows/daily-translate.yml
@@ -6,9 +6,11 @@ name: Daily Incremental Translation
 #
 # Prerequisites (set in repo Settings → Secrets and variables → Actions):
 #   - Secret  TRANSLATE_CODING_PLAN_API_KEY : a cloud-reachable model API key
-#   Model / base URL are set as plain env below; change them if you switch
-#   providers. The incremental baseline lives in website/last-sync.json
-#   (tracked in git), so each run only translates what changed upstream.
+#   - Variable (optional) TRANSLATE_BASE_URL : override the API endpoint.
+#     Defaults to https://coding.dashscope.aliyuncs.com/v1 when unset.
+#   QWEN_MODEL is still hardcoded below; change it if you switch models.
+#   The incremental baseline lives in website/last-sync.json (tracked in
+#   git), so each run only translates what changed upstream.
 #
 # Note: this job pushes to main with GITHUB_TOKEN, which by design does NOT
 # trigger other workflows (e.g. deploy-docs.yml), so there is no double build.
@@ -62,7 +64,7 @@ jobs:
         working-directory: ./website
         env:
           OPENAI_API_KEY: ${{ secrets.TRANSLATE_CODING_PLAN_API_KEY }}
-          OPENAI_BASE_URL: https://coding.dashscope.aliyuncs.com/v1
+          OPENAI_BASE_URL: ${{ vars.TRANSLATE_BASE_URL || 'https://coding.dashscope.aliyuncs.com/v1' }}
           QWEN_MODEL: qwen3.7-plus
           # Keep each response moderate; larger docs auto-chunk from this cap.
           QWEN_MAX_TOKENS: "32768"


### PR DESCRIPTION
## Background

`daily-translate.yml` 里 `OPENAI_BASE_URL` 是硬编码的 \`https://coding.dashscope.aliyuncs.com/v1\`，而 \`OPENAI_API_KEY\` 读的是 secret \`TRANSLATE_CODING_PLAN_API_KEY\`。两者必须匹配，否则 401。

当前 CI 已连续失败近一个月：
- 7/8 – 7/26：上游文档暴涨，6h timeout 被杀，基线卡住
- 7/27 至今：\`TRANSLATE_CODING_PLAN_API_KEY\` 对该 endpoint 401（token expired / invalid）

## Change

把 \`OPENAI_BASE_URL\` 改为读 repo Actions variable \`TRANSLATE_BASE_URL\`，未设置时 fallback 到当前值：

\`\`\`yaml
OPENAI_BASE_URL: \${{ vars.TRANSLATE_BASE_URL || 'https://coding.dashscope.aliyuncs.com/v1' }}
\`\`\`

行为零变化：不设 variable 时和现在完全一致；设了 variable 才生效。

## Why

合入后换 endpoint + key 不需要再改代码、提 PR。直接在 repo Settings → Secrets and variables → Actions → Variables 里加 \`TRANSLATE_BASE_URL\`，同时更新 secret \`TRANSLATE_CODING_PLAN_API_KEY\`，下一次 run 即可生效。

\`QWEN_MODEL\` 暂不动——如果换模型再单独改。

## Test

纯 workflow env 注入改动，语法已校验。实际行为需合入后配合 variable + secret 变更触发 \`workflow_dispatch\` 验证。