### PR TITLE
chore: hide design section from user-facing sidebar

### DIFF
--- a/website/content/de/_meta.ts
+++ b/website/content/de/_meta.ts
@@ -14,6 +14,7 @@ export default {
   design: {
     type: 'page',
     title: 'Design',
+    display: 'hidden',
   },
   showcase: {
     type: 'page',

--- a/website/content/en/_meta.ts
+++ b/website/content/en/_meta.ts
@@ -14,6 +14,7 @@ export default {
   design: {
     type: 'page',
     title: 'Design',
+    display: 'hidden',
   },
   showcase: {
     type: 'page',

--- a/website/content/fr/_meta.ts
+++ b/website/content/fr/_meta.ts
@@ -14,6 +14,7 @@ export default {
   design: {
     type: 'page',
     title: 'Design',
+    display: 'hidden',
   },
   showcase: {
     type: 'page',

--- a/website/content/ja/_meta.ts
+++ b/website/content/ja/_meta.ts
@@ -14,6 +14,7 @@ export default {
   design: {
     type: 'page',
     title: 'デザイン',
+    display: 'hidden',
   },
   showcase: {
     type: 'page',

--- a/website/content/pt-BR/_meta.ts
+++ b/website/content/pt-BR/_meta.ts
@@ -14,6 +14,7 @@ export default {
   design: {
     type: 'page',
     title: 'Design',
+    display: 'hidden',
   },
   showcase: {
     type: 'page',

--- a/website/content/ru/_meta.ts
+++ b/website/content/ru/_meta.ts
@@ -14,6 +14,7 @@ export default {
   design: {
     type: 'page',
     title: 'Дизайн',
+    display: 'hidden',
   },
   showcase: {
     type: 'page',

--- a/website/content/zh/_meta.ts
+++ b/website/content/zh/_meta.ts
@@ -14,6 +14,7 @@ export default {
   design: {
     type: 'page',
     title: '设计',
+    display: 'hidden',
   },
   showcase: {
     type: 'page',


### PR DESCRIPTION
## Background

The `design` section contains internal implementation design docs that should not be exposed to end users. Currently, all 7 locales expose a top-level `design` entry in the sidebar, visible to all users.

## Change

Add `display: 'hidden'` to the `design` block in each locale's `_meta.ts`:

```diff
   design: {
     type: 'page',
     title: 'Design',
+    display: 'hidden',
   },
```

**Files changed** (7):
- `website/content/en/_meta.ts`
- `website/content/zh/_meta.ts`
- `website/content/de/_meta.ts`
- `website/content/fr/_meta.ts`
- `website/content/ja/_meta.ts`
- `website/content/pt-BR/_meta.ts`
- `website/content/ru/_meta.ts`

## Effect

- Hide the `design` top-level entry from the sidebar; no longer visible to regular users.
- Direct URLs (`/{lang}/design/...`) remain accessible — internal collaborators and cross-references to design docs stay intact.
- Navbar, homepage, and OG image logic untouched.

## Test Report: Production vs Local

### Production (before)

Sidebar contains the "Design" entry:

![production before](https://raw.githubusercontent.com/QwenLM/qwen-code-docs/main/assets/prod-design.png)

### Local (after)

"Design" entry removed from sidebar:

![local after](https://raw.githubusercontent.com/QwenLM/qwen-code-docs/main/assets/local-design.png)

### DOM Verification

Ran puppeteer against the dev server and inspected sidebar top-level collapsible entries:

- **Before**: collapsibles include "Design"
- **After**: collapsibles only contain — User Guide, Developer Guide, Blog, Showcase
