### PR TITLE
perf(translator): add file-level concurrency to translation sync

### DIFF
--- a/.github/workflows/daily-translate.yml
+++ b/.github/workflows/daily-translate.yml
@@ -68,10 +68,10 @@ jobs:
           QWEN_MODEL: qwen3.7-plus
           # Keep each response moderate; larger docs auto-chunk from this cap.
           QWEN_MAX_TOKENS: "32768"
-          # The MaaS compatible endpoint can close long responses when all
-          # target languages run at once. Keep CI conservative and let API
-          # retries handle transient disconnects.
-          QWEN_TRANSLATION_CONCURRENCY: "3"
+          # Total in-flight API calls = QWEN_TRANSLATION_CONCURRENCY ×
+          # QWEN_FILE_CONCURRENCY. Tune down if the endpoint rate-limits.
+          QWEN_TRANSLATION_CONCURRENCY: "6"
+          QWEN_FILE_CONCURRENCY: "4"
           QWEN_API_MAX_RETRIES: "6"
           QWEN_CHUNK_CHARS: "12000"
         run: |

--- a/.github/workflows/daily-translate.yml
+++ b/.github/workflows/daily-translate.yml
@@ -8,6 +8,11 @@ name: Daily Incremental Translation
 #   - Secret  TRANSLATE_CODING_PLAN_API_KEY : a cloud-reachable model API key
 #   - Variable (optional) TRANSLATE_BASE_URL : override the API endpoint.
 #     Defaults to https://coding.dashscope.aliyuncs.com/v1 when unset.
+#   - Variable (optional) TRANSLATE_LANG_CONCURRENCY : languages translated
+#     in parallel (default 6).
+#   - Variable (optional) TRANSLATE_FILE_CONCURRENCY : files translated in
+#     parallel per language (default 4). Total in-flight API calls are the
+#     product of the two; lower them if the endpoint rate-limits.
 #   QWEN_MODEL is still hardcoded below; change it if you switch models.
 #   The incremental baseline lives in website/last-sync.json (tracked in
 #   git), so each run only translates what changed upstream.
@@ -69,9 +74,11 @@ jobs:
           # Keep each response moderate; larger docs auto-chunk from this cap.
           QWEN_MAX_TOKENS: "32768"
           # Total in-flight API calls = QWEN_TRANSLATION_CONCURRENCY ×
-          # QWEN_FILE_CONCURRENCY. Tune down if the endpoint rate-limits.
-          QWEN_TRANSLATION_CONCURRENCY: "6"
-          QWEN_FILE_CONCURRENCY: "4"
+          # QWEN_FILE_CONCURRENCY. Both are repo variables so they can be
+          # tuned in Settings → Variables without a code change; defaults
+          # below apply when unset. Tune down if the endpoint rate-limits.
+          QWEN_TRANSLATION_CONCURRENCY: ${{ vars.TRANSLATE_LANG_CONCURRENCY || '6' }}
+          QWEN_FILE_CONCURRENCY: ${{ vars.TRANSLATE_FILE_CONCURRENCY || '4' }}
           QWEN_API_MAX_RETRIES: "6"
           QWEN_CHUNK_CHARS: "12000"
         run: |

--- a/translator/src/sync.ts
+++ b/translator/src/sync.ts
@@ -5,6 +5,31 @@ import chalk from "chalk";
 import { DocumentTranslator } from "./translator";
 
 /**
+ * 并发池：以最多 concurrency 个并行任务处理 items 数组。
+ * 保持结果顺序与 items 一致，单线程事件循环下对共享计数器的
+ * 同步自增操作是安全的。
+ */
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  fn: (item: T) => Promise<R>
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let nextIndex = 0;
+
+  async function worker(): Promise<void> {
+    while (nextIndex < items.length) {
+      const index = nextIndex++;
+      results[index] = await fn(items[index]);
+    }
+  }
+
+  const workerCount = Math.min(concurrency, items.length);
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+  return results;
+}
+
+/**
  * 判断是否为 Nextra 导航文件（_meta.ts/js/json 等）。
  * 这类文件属于本库各语言包自行维护的导航定制，不应被上游同步覆盖或翻译。
  */
@@ -493,9 +518,15 @@ export class SyncManager {
         parseInt(process.env.QWEN_TRANSLATION_CONCURRENCY || "", 10) || 2
       )
     );
+    // 文件级并发：每种语言内部同时翻译多少个文件。默认 6；设为 1 即
+    // 退化为原来的串行行为。总并发 = languageConcurrency × fileConcurrency。
+    const fileConcurrency = Math.max(
+      1,
+      parseInt(process.env.QWEN_FILE_CONCURRENCY || "", 10) || 6
+    );
     console.log(
       chalk.yellow(
-        `🌍 开始翻译 ${this.targetLanguages.length} 种语言（并发: ${languageConcurrency}）...`
+        `🌍 开始翻译 ${this.targetLanguages.length} 种语言（语言并发: ${languageConcurrency}, 文件并发: ${fileConcurrency}）...`
       )
     );
 
@@ -511,7 +542,7 @@ export class SyncManager {
 
       console.log(chalk.blue(`🚀 启动 ${language} 翻译任务`));
 
-      for (const file of changedFiles) {
+      await mapWithConcurrency(changedFiles, fileConcurrency, async (file) => {
         try {
           const relativePath = file.replace(`${this.docsPath}/`, "");
 
@@ -521,7 +552,7 @@ export class SyncManager {
             console.log(
               chalk.gray(`  ↪ 跳过导航文件（不覆盖本地 _meta）: ${relativePath}`)
             );
-            continue;
+            return;
           }
 
           // 跳过配置中排除翻译的文档（内部文档/不在站点导航显示的页面）。
@@ -530,7 +561,7 @@ export class SyncManager {
             console.log(
               chalk.gray(`  ↪ 跳过翻译（excludeFromTranslation）: ${relativePath}`)
             );
-            continue;
+            return;
           }
           const sourcePath = path.join(
             this.outputBasePath,
@@ -552,7 +583,7 @@ export class SyncManager {
           // 检查源文件是否存在
           if (!(await fs.pathExists(sourcePath))) {
             console.log(chalk.yellow(`⚠️  源文件不存在: ${sourcePath}`));
-            continue;
+            return;
           }
 
           // 翻译文件
@@ -566,13 +597,12 @@ export class SyncManager {
 
           result.success++;
           result.files.push(relativePath);
-        } catch (error: any) {
-          console.error(
-            chalk.red(`❌ ${language}: ${file} - ${error.message}`)
-          );
+        } catch (error: unknown) {
+          const message = error instanceof Error ? error.message : String(error);
+          console.error(chalk.red(`❌ ${language}: ${file} - ${message}`));
           result.failed++;
         }
-      }
+      });
 
       console.log(
         chalk.blue(


### PR DESCRIPTION
## Problem

The daily translation CI keeps hitting the 6h \`timeout-minutes\` limit (every scheduled run 7/8–7/26 was cancelled at exactly 6h0m). Root cause: within each language, files are translated **serially** in a \`for\` loop, so total parallelism equals \`QWEN_TRANSLATION_CONCURRENCY\` (3). With a ~1-month upstream backlog (baseline stuck at 2026-07-08), a full run needs 4–6h+.

Measured from the last successful run (7/7): 32 files × 6 languages ≈ 192 tasks over 3h51m ≈ **3.6 min per concurrency batch** — dominated by API latency/retries, not CPU. More parallelism is the only lever.

## Change

1. **File-level concurrency pool** (\`translator/src/sync.ts\`): added a small dependency-free \`mapWithConcurrency\` helper and replaced the serial per-language \`for\` loop with it. Per-file error handling is preserved — one failed file doesn't abort its siblings.
2. **New \`QWEN_FILE_CONCURRENCY\` env var**: files in flight per language, default 6. Set to \`1\` to restore the old serial behavior.
3. **CI config** (\`daily-translate.yml\`): \`QWEN_TRANSLATION_CONCURRENCY\` 3 → 6, plus \`QWEN_FILE_CONCURRENCY: "4"\` ⇒ **24 total in-flight API calls** (was 3), an 8× concurrency increase.

## Expected impact

- 192-task backlog: ~4h → ~30–40 min
- Daily incremental runs (few changed files): minutes → sub-minute
- Also makes 6h timeouts far less likely even for large upstream batches

## Risk & mitigation

- **Rate limiting / disconnects**: the original serial design existed to avoid the MaaS endpoint closing long connections under load. Total concurrency is now tunable via two env vars — if 429s or disconnects appear, drop \`QWEN_FILE_CONCURRENCY\` first (e.g. \`"2"\`), no code change needed. Retries with backoff are already in place.
- **Log interleaving**: unchanged — \`translateDocument\` already buffers logs and flushes atomically.
- **Baseline semantics**: unchanged — \`last-sync.json\` still advances only after the whole sync; failed files still fail the run and block commit.

## Verification

- \`tsc --noEmit --skipLibCheck\` on \`sync.ts\`: clean
- Workflow YAML validated
- Behavior with \`QWEN_FILE_CONCURRENCY=1\` is equivalent to the previous serial loop

## Follow-up

Once merged, cancel any in-flight run and re-trigger \`workflow_dispatch\` to clear the 7/8 backlog with the new concurrency.