### PR TITLE
feat(website): add Korean (ko) locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A documentation translation tool specifically designed for the github project. A
 
 ## Features
 
-- 🌍 **Multi-language Support**: Translate documentation to Chinese (zh), German (de), French (fr), Russian (ru), Japanese (ja), and Spanish (es)
+- 🌍 **Multi-language Support**: Translate documentation to Chinese (zh), German (de), French (fr), Russian (ru), Japanese (ja), Portuguese (pt-BR), Spanish (es), and Korean (ko)
 - 🤖 **Qwen AI Translation**: Powered by Qwen API for high-quality technical document translation
 - 📚 **Nextra Integration**: Automatically generates a modern documentation site using Nextra
 - 🔄 **Git Synchronization**: Automatically syncs with source repositories to keep translations up-to-date
@@ -71,7 +71,7 @@ Sync source repository documents and automatically translate changed files into 
 
 Translate the Markdown documents under `content/<sourceLanguage>/` into the target languages. Translates the whole directory by default, or a single file with `-f`.
 
-- `-l, --language <lang>`: Specify target language (zh, de, fr, ru, ja, pt-BR, es)
+- `-l, --language <lang>`: Specify target language (zh, de, fr, ru, ja, pt-BR, es, ko)
 - `-f, --file <file>`: Specify single file to translate
 
 ### `meta [options]`

--- a/translator/README.md
+++ b/translator/README.md
@@ -4,7 +4,7 @@ A documentation translation tool specifically designed for the github project. A
 
 ## Features
 
-- 🌍 **Multi-language Support**: Translate documentation to Chinese (zh), German (de), French (fr), Russian (ru), Japanese (ja), and Spanish (es)
+- 🌍 **Multi-language Support**: Translate documentation to Chinese (zh), German (de), French (fr), Russian (ru), Japanese (ja), Portuguese (pt-BR), Spanish (es), and Korean (ko)
 - 🤖 **Qwen AI Translation**: Powered by Qwen API for high-quality technical document translation
 - 📚 **Nextra Integration**: Automatically generates a modern documentation site using Nextra
 - 🔄 **Git Synchronization**: Automatically syncs with source repositories to keep translations up-to-date
@@ -71,7 +71,7 @@ Sync source repository documents and automatically translate changed files into 
 
 Translate the Markdown documents under `content/<sourceLanguage>/` into the target languages. Translates the whole directory by default, or a single file with `-f`.
 
-- `-l, --language <lang>`: Specify target language (zh, de, fr, ru, ja, pt-BR, es)
+- `-l, --language <lang>`: Specify target language (zh, de, fr, ru, ja, pt-BR, es, ko)
 - `-f, --file <file>`: Specify single file to translate
 
 ### `meta [options]`

--- a/translator/src/cli.ts
+++ b/translator/src/cli.ts
@@ -93,6 +93,7 @@ class TranslationCLI {
           { name: "Russian (ru)", value: "ru" },
           { name: "Japanese (ja)", value: "ja" },
           { name: "Spanish (es)", value: "es" },
+          { name: "Korean (ko)", value: "ko" },
         ],
         default: "en",
       },
@@ -114,6 +115,11 @@ class TranslationCLI {
           {
             name: "Spanish (es)",
             value: "es",
+            checked: false,
+          },
+          {
+            name: "Korean (ko)",
+            value: "ko",
             checked: false,
           },
         ],
@@ -547,6 +553,7 @@ class TranslationCLI {
           { name: "Japanese (ja)", value: "ja" },
           { name: "Portuguese (Brazil) (pt-BR)", value: "pt-BR" },
           { name: "Spanish (es)", value: "es" },
+          { name: "Korean (ko)", value: "ko" },
         ],
         default: currentConfig.targetLanguages,
       },

--- a/translator/src/meta-translator.ts
+++ b/translator/src/meta-translator.ts
@@ -29,6 +29,7 @@ export class MetaTranslator {
       "ru",
       "pt-BR",
       "es",
+      "ko",
     ];
     this.outputDir = options.outputDir || "content";
     this.translator = new DocumentTranslator({

--- a/translator/src/sync.ts
+++ b/translator/src/sync.ts
@@ -115,6 +115,7 @@ export class SyncManager {
       "ru",
       "pt-BR",
       "es",
+      "ko",
     ];
     this.branch = options.branch || "main"; // 默认使用 main 分支
     this.excludeFromTranslation = options.excludeFromTranslation || [];

--- a/translator/src/translator.ts
+++ b/translator/src/translator.ts
@@ -261,6 +261,7 @@ ${terminologyContent}
       ja: "Japanese",
       "pt-BR": "Portuguese (Brazil)",
       es: "Spanish",
+      ko: "Korean",
     };
 
     const targetLanguageName = languageNames[targetLang] || targetLang;
@@ -322,6 +323,7 @@ ${terminology}${sliceNote}
       ja: "Japanese",
       "pt-BR": "Portuguese (Brazil)",
       es: "Spanish",
+      ko: "Korean",
     };
 
     const targetLanguageName = languageNames[targetLang] || targetLang;

--- a/website/app/[lang]/[[...mdxPath]]/page.jsx
+++ b/website/app/[lang]/[[...mdxPath]]/page.jsx
@@ -23,7 +23,7 @@ export const generateStaticParams = async () => {
   });
 };
 
-const LOCALES = ["en", "zh", "de", "fr", "ru", "ja", "pt-BR"];
+const LOCALES = ["en", "zh", "de", "fr", "ru", "ja", "pt-BR", "ko"];
 
 // OG 图片映射
 const OG_IMAGE_MAP = {

--- a/website/app/[lang]/layout.tsx
+++ b/website/app/[lang]/layout.tsx
@@ -77,6 +77,7 @@ const LanguageLayout: FC<LayoutProps> = async ({ children, params }) => {
     lang === "fr" ? "Rechercher dans la documentation..." :
     lang === "ru" ? "Поиск в документации..." :
     lang === "pt-BR" ? "Pesquisar documentação..." :
+    lang === "ko" ? "문서 검색..." :
     "Search documentation..."
   } lang={lang} className='shrink-0' />
       <GitHubStarLink projectLink='https://github.com/QwenLM/qwen-code' className='shrink-0' />
@@ -100,6 +101,7 @@ const LanguageLayout: FC<LayoutProps> = async ({ children, params }) => {
         { locale: "ru", name: "Русский" },
         { locale: "ja", name: "日本語" },
         { locale: "pt-BR", name: "Português (BR)" },
+        { locale: "ko", name: "한국어" },
       ]}
       search={false}
       sidebar={{ defaultMenuCollapseLevel: 2 }}

--- a/website/app/sitemap.ts
+++ b/website/app/sitemap.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { execSync } from "node:child_process";
 
-const LOCALES = ["en", "zh", "de", "fr", "ru", "ja", "pt-BR"] as const;
+const LOCALES = ["en", "zh", "de", "fr", "ru", "ja", "pt-BR", "ko"] as const;
 
 export function generateStaticParams() {
   return [{ __metadata_id__: [] }];

--- a/website/next.config.mjs
+++ b/website/next.config.mjs
@@ -18,7 +18,7 @@ export default withNextra({
   basePath: assetPrefix,
   assetPrefix: assetPrefix,
   i18n: {
-    locales: ["en", "zh", "de", "fr", "ru", "ja", "pt-BR"],
+    locales: ["en", "zh", "de", "fr", "ru", "ja", "pt-BR", "ko"],
     defaultLocale: "en",
   },
   eslint: {

--- a/website/scripts/set-html-lang.js
+++ b/website/scripts/set-html-lang.js
@@ -21,6 +21,7 @@ const langMap = {
   ru: 'ru',
   ja: 'ja',
   'pt-BR': 'pt-BR',
+  ko: 'ko',
 };
 
 function processDirectory(dirPath, lang) {

--- a/website/src/components/blog-index-client.tsx
+++ b/website/src/components/blog-index-client.tsx
@@ -50,6 +50,10 @@ const BLOG_COPY: Record<string, { title: string; description: string }> = {
     title: "Blog Qwen Code",
     description: "Atualizações de programação com IA, lançamentos, fluxos de trabalho e guias práticos para desenvolvedores.",
   },
+  ko: {
+    title: "Qwen Code 블로그",
+    description: "AI 코딩 소식, 제품 릴리스, 워크플로, 개발자를 위한 실전 가이드.",
+  },
 };
 
 export const BlogIndexClient = ({ posts, lang }: BlogIndexClientProps) => {

--- a/website/src/components/custom-navbar.tsx
+++ b/website/src/components/custom-navbar.tsx
@@ -81,7 +81,7 @@ const getUserLanguage = (): string => {
 
   if (pathSegments.length > 0) {
     const possibleLang = pathSegments[0];
-    const supportedLanguages = ["en", "zh", "de", "fr", "ru", "ja", "pt-BR"];
+    const supportedLanguages = ["en", "zh", "de", "fr", "ru", "ja", "pt-BR", "ko"];
     if (supportedLanguages.includes(possibleLang)) {
       return possibleLang;
     }
@@ -95,6 +95,7 @@ const getUserLanguage = (): string => {
   if (browserLang.startsWith("ru")) return "ru";
   if (browserLang.startsWith("ja")) return "ja";
   if (browserLang.startsWith("pt")) return "pt-BR";
+  if (browserLang.startsWith("ko")) return "ko";
 
   return "en"; // 默认英文
 };

--- a/website/src/components/language-dropdown.tsx
+++ b/website/src/components/language-dropdown.tsx
@@ -14,6 +14,7 @@ export const languages = [
   { locale: "ru", name: "Русский", flag: "🇷🇺" },
   { locale: "ja", name: "日本語", flag: "🇯🇵" },
   { locale: "pt-BR", name: "Português (BR)", flag: "🇧🇷" },
+  { locale: "ko", name: "한국어", flag: "🇰🇷" },
 ];
 
 const languageLocales = languages.map((language) => language.locale);

--- a/website/src/components/locale-anchor.tsx
+++ b/website/src/components/locale-anchor.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import React from "react";
 
-const LOCALES = ["en", "zh", "de", "fr", "ru", "ja", "pt-BR"] as const;
+const LOCALES = ["en", "zh", "de", "fr", "ru", "ja", "pt-BR", "ko"] as const;
 type Locale = (typeof LOCALES)[number];
 
 function LinkArrowIcon(props: React.SVGProps<SVGSVGElement>) {

--- a/website/src/components/mobile-menu.tsx
+++ b/website/src/components/mobile-menu.tsx
@@ -26,6 +26,7 @@ const NAV_I18N: Record<string, Record<string, string>> = {
     ja: "ドキュメント",
     ru: "Документация",
     "pt-BR": "Documentação",
+    ko: "문서",
   },
   blog: {
     zh: "博客",
@@ -35,6 +36,7 @@ const NAV_I18N: Record<string, Record<string, string>> = {
     ja: "ブログ",
     ru: "Блог",
     "pt-BR": "Blog",
+    ko: "블로그",
   },
   showcase: {
     zh: "案例展示",
@@ -44,6 +46,7 @@ const NAV_I18N: Record<string, Record<string, string>> = {
     ja: "ショーケース",
     ru: "Витрина",
     "pt-BR": "Showcase",
+    ko: "쇼케이스",
   },
   language: {
     zh: "语言",
@@ -53,6 +56,7 @@ const NAV_I18N: Record<string, Record<string, string>> = {
     ja: "言語",
     ru: "Язык",
     "pt-BR": "Idioma",
+    ko: "언어",
   },
   menu: {
     zh: "打开菜单",
@@ -62,6 +66,7 @@ const NAV_I18N: Record<string, Record<string, string>> = {
     ja: "メニューを開く",
     ru: "Открыть меню",
     "pt-BR": "Abrir menu",
+    ko: "메뉴 열기",
   },
   close: {
     zh: "关闭菜单",
@@ -71,6 +76,7 @@ const NAV_I18N: Record<string, Record<string, string>> = {
     ja: "メニューを閉じる",
     ru: "Закрыть меню",
     "pt-BR": "Fechar menu",
+    ko: "메뉴 닫기",
   },
 };
 

--- a/website/src/lib/blog-utils.ts
+++ b/website/src/lib/blog-utils.ts
@@ -8,6 +8,7 @@ const LOCALE_MAP: Record<string, string> = {
   ru: "ru-RU",
   ja: "ja-JP",
   "pt-BR": "pt-BR",
+  ko: "ko-KR",
 };
 
 export function getLocale(lang: string): string {
@@ -50,6 +51,7 @@ const CATEGORY_I18N: Record<string, Record<string, CategoryInfo>> = {
     ja: { title: "はじめに", description: "Qwen Code のコアコンセプトを学び、AI プログラミングを素早く始めましょう。" },
     ru: { title: "Начало работы", description: "Изучите основные концепции Qwen Code и быстро начните программировать с ИИ." },
     "pt-BR": { title: "Introdução", description: "Aprenda os conceitos fundamentais do Qwen Code e comece a programar com IA rapidamente." },
+    ko: { title: "시작하기", description: "Qwen Code의 핵심 개념을 익히고 AI 코딩을 빠르게 시작해 보세요." },
   },
   cases: {
     zh: { title: "实战案例", description: "真实使用场景和教程，从办公自动化到代码开发。" },
@@ -59,6 +61,7 @@ const CATEGORY_I18N: Record<string, Record<string, CategoryInfo>> = {
     ja: { title: "活用事例", description: "オフィス自動化からコード開発まで、実際の使用シナリオとチュートリアル。" },
     ru: { title: "Примеры использования", description: "Реальные сценарии и руководства: от автоматизации офиса до разработки кода." },
     "pt-BR": { title: "Casos de Uso", description: "Cenários reais e tutoriais, desde automação de escritório até desenvolvimento de código." },
+    ko: { title: "활용 사례", description: "업무 자동화부터 코드 개발까지, 실제 사용 시나리오와 튜토리얼." },
   },
   advanced: {
     zh: { title: "进阶应用", description: "Skills、百炼 CLI、公众号封面等高级功能指南。" },
@@ -68,6 +71,7 @@ const CATEGORY_I18N: Record<string, Record<string, CategoryInfo>> = {
     ja: { title: "上級ガイド", description: "Skills、Bailian CLI、WeChat カバー生成などの高度な機能ガイド。" },
     ru: { title: "Продвинутый", description: "Расширенные руководства по Skills, Bailian CLI, генерации обложек WeChat и другому." },
     "pt-BR": { title: "Avançado", description: "Guias avançados para Skills, Bailian CLI, geração de capas WeChat e mais." },
+    ko: { title: "고급 활용", description: "Skills, Bailian CLI, WeChat 커버 생성 등 고급 기능 가이드." },
   },
   updates: {
     zh: { title: "功能更新", description: "每周产品版本发布记录、新功能与社区动态。" },
@@ -77,6 +81,7 @@ const CATEGORY_I18N: Record<string, Record<string, CategoryInfo>> = {
     ja: { title: "機能アップデート", description: "毎週の製品リリース、新機能、コミュニティのハイライト。" },
     ru: { title: "Обновления функций", description: "Еженедельные релизы, новые функции и новости сообщества." },
     "pt-BR": { title: "Atualizações de Recursos", description: "Lançamentos semanais, novos recursos e destaques da comunidade." },
+    ko: { title: "기능 업데이트", description: "주간 제품 릴리스, 새로운 기능, 커뮤니티 소식." },
   },
 };
 
@@ -89,6 +94,7 @@ const BLOG_I18N: Record<string, Record<string, string>> = {
     ja: "Qwen Code ブログ",
     ru: "Блог Qwen Code",
     "pt-BR": "Blog Qwen Code",
+    ko: "Qwen Code 블로그",
   },
   blogDescription: {
     zh: "获取产品更新、AI 编程实践、功能发布和真实案例。",
@@ -98,6 +104,7 @@ const BLOG_I18N: Record<string, Record<string, string>> = {
     ja: "製品アップデート、AI プログラミング実践、機能リリース、実際の活用事例。",
     ru: "Обновления продукта, практики AI-программирования, выпуски функций и реальные кейсы.",
     "pt-BR": "Atualizações de produto, práticas de codificação IA, lançamentos e casos reais.",
+    ko: "제품 업데이트, AI 코딩 실전 노하우, 기능 릴리스, 실제 활용 사례.",
   },
   recentUpdates: {
     zh: "最近更新",
@@ -107,6 +114,7 @@ const BLOG_I18N: Record<string, Record<string, string>> = {
     ja: "最近の更新",
     ru: "Последние обновления",
     "pt-BR": "Atualizações Recentes",
+    ko: "최근 업데이트",
   },
   noArticles: {
     zh: "暂无文章",
@@ -116,6 +124,7 @@ const BLOG_I18N: Record<string, Record<string, string>> = {
     ja: "記事はまだありません",
     ru: "Статей пока нет",
     "pt-BR": "Nenhum artigo ainda",
+    ko: "아직 게시글이 없습니다",
   },
   pastUpdates: {
     zh: "往期更新",
@@ -125,6 +134,7 @@ const BLOG_I18N: Record<string, Record<string, string>> = {
     ja: "過去の更新",
     ru: "Предыдущие обновления",
     "pt-BR": "Atualizações Anteriores",
+    ko: "지난 업데이트",
   },
   allArticles: {
     zh: "全部",
@@ -134,6 +144,7 @@ const BLOG_I18N: Record<string, Record<string, string>> = {
     ja: "すべて",
     ru: "Все",
     "pt-BR": "Todos",
+    ko: "전체",
   },
   loadMore: {
     zh: "显示更多",
@@ -143,6 +154,7 @@ const BLOG_I18N: Record<string, Record<string, string>> = {
     ja: "もっと見る",
     ru: "Показать ещё",
     "pt-BR": "Mostrar mais",
+    ko: "더 보기",
   },
 };
 

--- a/website/src/lib/structured-data.ts
+++ b/website/src/lib/structured-data.ts
@@ -28,7 +28,7 @@ export function getSiteStructuredData(siteUrl: string) {
       publisher: {
         "@id": organizationId,
       },
-      inLanguage: ["en", "zh", "de", "fr", "ru", "ja", "pt-BR"],
+      inLanguage: ["en", "zh", "de", "fr", "ru", "ja", "pt-BR", "ko"],
     },
   ];
 

--- a/website/translation.config.json
+++ b/website/translation.config.json
@@ -3,7 +3,7 @@
   "sourceRepo": "https://github.com/QwenLM/qwen-code.git",
   "docsPath": "docs",
   "sourceLanguage": "en",
-  "targetLanguages": ["zh", "de", "fr", "ru", "ja", "pt-BR"],
+  "targetLanguages": ["zh", "de", "fr", "ru", "ja", "pt-BR", "ko"],
   "outputDir": "content",
   "branch": "main",
   "excludeFromTranslation": [


### PR DESCRIPTION
## What

Registers Korean (`ko`) across every place the locale set is hardcoded, so that:

- the daily incremental translation workflow generates and deploys `content/ko/**`
- the language switcher offers **한국어** and `/ko/...` routes render correctly
- the mobile menu, blog index, sitemap, hreflang alternates and `html[lang]` are all correct for `ko`

## Why

The site ships `zh`, `de`, `fr`, `ru`, `ja` and `pt-BR`, but not Korean.

This also unblocks adding a 한국어 entry to the language bar in the main
[`QwenLM/qwen-code` README](https://github.com/QwenLM/qwen-code/blob/main/README.md),
which today cannot list Korean because `/ko/users/overview` returns 404.

## Relationship to #149

#149 proposes the same feature and was the starting point here. Since it was opened
(2026-07-13) `main` gained new locale-keyed surfaces, so #149 is now incomplete —
merging it as-is would leave Korean visitors with English (or missing) strings:

| File | Why #149 misses it |
|---|---|
| `website/src/components/mobile-menu.tsx` | added 2026-07-31, after #149 — 6 locale-keyed label maps |
| `website/src/lib/blog-utils.ts` | blog i18n extracted here 2026-07-14, after #149 — 12 locale-keyed entries |
| `website/app/[lang]/[[...mdxPath]]/page.jsx` | its own `LOCALES` list, used to build hreflang alternates |
| `translator/src/translator.ts` | #149 does not touch the translator, so the prompt would ask the model to translate "to **ko**" rather than "to Korean" |

Opened as a separate PR rather than a patch on #149 so the rebased work is reviewable
on its own. No hard feelings either way — happy to close this in favour of #149 if
@dss1222 wants to rebase and pick these up instead. Whichever lands Korean sooner.

## Changes

**Website — locale registration**

| File | Change |
|---|---|
| `website/translation.config.json` | add `ko` to `targetLanguages` |
| `website/next.config.mjs` | add `ko` to `i18n.locales` |
| `website/app/[lang]/layout.tsx` | add `ko` to `LOCALES`, the i18n name map (`한국어`), and the search placeholder |
| `website/app/[lang]/[[...mdxPath]]/page.jsx` | add `ko` to `LOCALES` (hreflang alternates) |
| `website/app/sitemap.ts` | add `ko` to `LOCALES` |
| `website/scripts/set-html-lang.js` | add `ko` to `langMap` |
| `website/src/components/language-dropdown.tsx` | add 한국어 🇰🇷 |
| `website/src/components/locale-anchor.tsx` | add `ko` to `LOCALES` |
| `website/src/components/custom-navbar.tsx` | add `ko` to `supportedLanguages` + browser-language detection |
| `website/src/lib/structured-data.ts` | add `ko` to `inLanguage` |

**Website — Korean UI strings** (hand-written, not machine-translated)

| File | Change |
|---|---|
| `website/src/components/mobile-menu.tsx` | 문서 / 블로그 / 쇼케이스 / 언어 / 메뉴 열기 / 메뉴 닫기 |
| `website/src/lib/blog-utils.ts` | `ko-KR` locale, 4 blog categories, 7 blog UI strings |
| `website/src/components/blog-index-client.tsx` | blog index title + description |

**Translator** (same shape as the merged Spanish PR #104)

| File | Change |
|---|---|
| `translator/src/translator.ts` | `ko: "Korean"` in both `languageNames` maps |
| `translator/src/sync.ts`, `translator/src/meta-translator.ts` | add `ko` to the default target list |
| `translator/src/cli.ts` | offer Korean in the `init` and `config` prompts |
| `README.md`, `translator/README.md` | document the supported set (also restores the missing `pt-BR`) |

## Reviewer test plan

Both verified locally:

- `cd translator && npm ci && npm run build` — clean `tsc`
- `cd website && npm ci && NODE_OPTIONS=--max-old-space-size=10240 npm run build` —
  `✓ Compiled successfully`, `✓ Generating static pages (1722/1722)`, exit 0
  (the heap flag mirrors what CI already sets in `deploy-docs.yml` / `daily-translate.yml`)

**Safe to merge before any Korean content exists.** `scripts/generate-page-registry.js`
derives locales from the `content/` directories, and `getAlternatePath()` gates each
hreflang on `hasContentPage()`. Confirmed on the local build: no `out/ko` directory and
no `ko` hreflang were emitted. `/ko/**` appears only after the next `daily-translate`
run produces `content/ko/**`.

## Notes

- `translator/nextra-template/**` is intentionally untouched — the scaffold's locale
  lists are already out of sync with the live site (they lack `pt-BR`), so refreshing
  them belongs in a separate PR.
