### PR TITLE
ci: alert when the scheduled translation sync fails

### DIFF
--- a/.github/workflows/daily-translate.yml
+++ b/.github/workflows/daily-translate.yml
@@ -32,6 +32,9 @@ on:
 
 permissions:
   contents: write
+  # Needed by the failure-reporting step below, which files/updates a tracking
+  # issue when a scheduled run fails.
+  issues: write
 
 concurrency:
   group: daily-translate
@@ -108,6 +111,24 @@ jobs:
             echo "No upstream doc changes today — nothing to do."
           fi
 
+      # Runs after the sync has rewritten last-sync.json, so the age reported
+      # here reflects this run's outcome. Catches the failure mode a
+      # failure()-gated alert cannot: the job goes green but the baseline
+      # never actually advanced, so the backlog keeps growing silently.
+      - name: Warn if baseline is stale
+        run: |
+          set -euo pipefail
+          TS="$(jq -r '.timestamp // empty' website/last-sync.json)"
+          if [ -z "$TS" ]; then
+            echo "::warning::last-sync.json has no timestamp field; cannot check baseline age."
+            exit 0
+          fi
+          AGE=$(( ( $(date -u +%s) - $(date -u -d "$TS" +%s) ) / 86400 ))
+          echo "Baseline age: ${AGE}d (last sync: $TS)"
+          if [ "$AGE" -gt 3 ]; then
+            echo "::warning::last-sync.json has not advanced in ${AGE} days — the translation backlog is growing."
+          fi
+
       - name: Build website
         if: steps.detect.outputs.changed == 'true'
         working-directory: ./website
@@ -130,3 +151,37 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./website/out
+
+      # Must stay last so it observes failures from any step above.
+      #
+      # Scheduled failures are otherwise invisible: GitHub only emails the
+      # workflow author on cron-triggered failures, and that mail is easy to
+      # filter. An expired API key took down six consecutive nightly runs
+      # (07-29..08-03) before anyone noticed, freezing the sync baseline at
+      # 2026-07-08 while the backlog grew to ~1800 file-translations.
+      #
+      # Gated to `schedule` so manual workflow_dispatch debugging runs — which
+      # are expected to fail while iterating — never file issues.
+      - name: Report scheduled failure
+        if: failure() && github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          TITLE="Daily translation sync is failing"
+          BODY="Scheduled run failed: ${RUN_URL} (commit \`${GITHUB_SHA}\`)"
+          # Collapse a run of consecutive failures onto one open issue: a week
+          # of breakage becomes one issue with seven comments, not seven
+          # issues. Closing the issue after a fix re-arms the alert.
+          NUM="$(gh issue list --repo "$GITHUB_REPOSITORY" \
+                   --state open --label ci-failure --search "$TITLE in:title" \
+                   --json number --jq '.[0].number // empty')"
+          if [ -n "$NUM" ]; then
+            echo "Commenting on existing tracking issue #${NUM}"
+            gh issue comment "$NUM" --repo "$GITHUB_REPOSITORY" --body "$BODY"
+          else
+            echo "Filing new tracking issue"
+            gh issue create --repo "$GITHUB_REPOSITORY" \
+              --title "$TITLE" --label ci-failure --body "$BODY"
+          fi


### PR DESCRIPTION
Closes #188.

## Problem

The daily translation workflow failed on **six consecutive nights** (07-29 … 08-03) with `API error: 401 - invalid access token or token expired`, and nobody noticed for a week.

GitHub only emails the *workflow author* on `schedule`-triggered failures, and that mail is easy to filter. Meanwhile `website/last-sync.json` stayed frozen at **2026-07-08** and the backlog grew to ~1,800 file-translations — which is the direct cause of the multi-hour catch-up runs.

The expired key (#187) was the trigger. **The missing alarm is the defect** — any future silent failure (rate limits, quota, upstream schema change) plays out identically.

## Changes

**1. `Report scheduled failure`** — final step, `if: failure() && github.event_name == 'schedule'`.

- Files a `ci-failure` tracking issue, or **comments on the existing open one**. A week of breakage becomes one issue with seven comments, not seven issues. Closing the issue after a fix re-arms the alert.
- Placed last so it observes a failure from any step above.
- Gated to `schedule` so `workflow_dispatch` debugging runs — which are *expected* to fail while iterating — never file issues.
- `permissions:` gains `issues: write` (previously `contents: write` only).

**2. `Warn if baseline is stale`** — a `failure()`-gated alert cannot catch the inverse failure mode: the job goes **green** but the baseline never advanced, so the backlog grows silently. This warns when `last-sync.json` is more than 3 days old. Placed after the sync has rewritten the file, so the age reflects this run's outcome.

## Verification

- **`actionlint` clean** (v1.7.7), YAML parses, step order and `if:` conditions confirmed.
- **Staleness logic run against the real `website/last-sync.json`**, which is genuinely stale today:
  ```
  TS=2026-07-08T01:11:07.836Z
  AGE=28d
  ::warning::last-sync.json has not advanced in 28 days
  ```
  This is the live bug the check is meant to surface — it fires correctly on current `main`.
- **Guards tested** for a missing `.timestamp` field and an explicit `null` — both warn and exit 0 rather than failing the job with a `date` parse error. This matters because #182 proposes a `last-sync.json` format that may not carry `timestamp`; the step degrades instead of breaking.
- **Dedupe query executed read-only** against this repo: returns empty, i.e. the first failure correctly files a new issue rather than silently no-op'ing.
- `jq`, `date -d` and `gh` are all preinstalled on `ubuntu-latest`.

## Not verified end-to-end

The create/comment paths are **not** exercised against a live failing scheduled run — doing so would require either waiting for a real nightly failure or deliberately breaking `main`'s schedule. The issue-filing commands themselves are standard `gh` invocations and the dedupe query is verified above.

Suggested acceptance test after merge, per #188: temporarily add `- run: exit 1` on a scratch branch with the gate flipped to `workflow_dispatch`, dispatch twice, and confirm one issue plus one comment.

## Scope

Deliberately excludes Slack/DingTalk routing. A tracking issue in this repo is the lowest-friction channel guaranteed to reach maintainers; a chat webhook can be layered on later.
