### PR TITLE
ci: enable npm caching and shallow checkouts in both workflows

### DIFF
--- a/.github/workflows/daily-translate.yml
+++ b/.github/workflows/daily-translate.yml
@@ -86,12 +86,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
-          fetch-depth: 0
+          # Nothing in this pipeline needs repo history: the commit step
+          # pushes HEAD:main (serialized by the concurrency group below),
+          # and the upstream diff uses its own shallow clone of qwen-code.
+          # Nextra's git-based "last modified" timestamps were already
+          # degraded with full history (logged warnings), so depth 1 loses
+          # nothing that worked before.
+          fetch-depth: 1
 
       - name: Install Node.js
         uses: actions/setup-node@v6
         with:
           node-version: 22
+          cache: npm
+          cache-dependency-path: |
+            website/package-lock.json
+            translator/package-lock.json
 
       - name: Install qwen CLI
         run: npm i -g @qwen-code/qwen-code@0.21.1

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -16,12 +16,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
-          fetch-depth: 0
+          # The build only needs the current tree; Nextra's git-based
+          # "last modified" timestamps were already degraded with full
+          # history (logged warnings), so depth 1 loses nothing that
+          # worked before.
+          fetch-depth: 1
 
       - name: Install Node.js
         uses: actions/setup-node@v6
         with:
           node-version: 22
+          cache: npm
+          cache-dependency-path: website/package-lock.json
 
       - name: Install dependencies
         run: npm ci --no-audit --no-fund


### PR DESCRIPTION
## What

Fixes #191. Two setup-cost cuts in both workflows:

1. **npm caching** — `actions/setup-node` gets `cache: npm`, keyed on the package-locks (`website` + `translator` for `daily-translate.yml`, `website` only for `deploy-docs.yml`). `daily-translate.yml` runs `npm ci` twice per run, previously always cold.
2. **Shallow checkout** — `fetch-depth: 0 → 1`. Nothing in either pipeline needs repo history:
   - the commit step pushes `HEAD:main`, serialized by the existing concurrency group;
   - the upstream diff uses its own shallow clone of `qwen-code` (`.temp-source-repo`), not this repo's history;
   - Nextra's git-based "last modified" timestamps were *already* degraded with full history (run 30978893172 logs `warn [nextra] Failed to get the last modified timestamp from Git`), so depth 1 loses nothing that worked before.

Both changes carry comments in the YAML explaining the reasoning, so the next person doesn't have to re-derive it.

## Verification plan

- Cache: first run populates, second run must log `Cache restored from key: …` with visibly faster `npm ci`.
- Depth 1: tonight's/next scheduled run must still commit-and-push successfully on `main` (this PR changes nothing about that path except how much history the runner holds).
- If "last updated" timestamps on the built site regress beyond today's already-warning state, raise `fetch-depth` rather than reverting to `0`.

Safe to merge ahead of tonight's 20:00 UTC scheduled run: worst case is a cache miss (identical behavior to today). Expected gain ~4–6 min/run on every run, including the frequent `deploy-docs.yml` push builds.

<details><summary>中文</summary>

## 内容

修复 #191。两个 workflow 的两项 setup 成本削减：

1. **npm 缓存**——`actions/setup-node` 加 `cache: npm`，以 package-lock 为键（`daily-translate.yml` 用 `website` + `translator`，`deploy-docs.yml` 只用 `website`）。`daily-translate.yml` 每次 run 跑两次 `npm ci`，之前全是冷启动。
2. **浅克隆**——`fetch-depth: 0 → 1`。两条流水线都不需要仓库历史：
   - commit 步推 `HEAD:main`，由既有 concurrency 组串行化；
   - 上游 diff 用的是自己的 `qwen-code` 浅克隆（`.temp-source-repo`），不是本仓库历史；
   - Nextra 基于 git 的"最后修改"时间戳在全量历史下**本来就已经失效**（run 30978893172 有 `warn [nextra] Failed to get the last modified timestamp from Git` 日志），depth 1 不会丢掉任何此前正常工作的东西。

两处改动的理由都写进了 YAML 注释，下一个人不用重新推导。

## 验证计划

- 缓存：第一次 run 填充，第二次 run 必须出现 `Cache restored from key: …` 且 `npm ci` 明显变快。
- Depth 1：今晚/下次 scheduled run 必须仍能在 main 上成功 commit + push（本 PR 对该路径唯一改变是 runner 持有多少历史）。
- 如果站点"最后更新"时间戳退化到超过今天已告警的状态，调高 `fetch-depth` 而不是退回 `0`。

可以在今晚 20:00 UTC scheduled run 之前合并：最坏情况是缓存未命中（行为与今天完全相同）。预期每次 run 省 ~4–6 分钟，包括高频的 `deploy-docs.yml` push 构建。

</details>
