### PR TITLE
ci: drop translation-changelog.json from the artifact upload

### DIFF
--- a/.github/workflows/daily-translate.yml
+++ b/.github/workflows/daily-translate.yml
@@ -207,10 +207,12 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: translation-output
+          # translation-changelog.json is deliberately not listed: the
+          # orchestrator pipeline does not produce it (legacy-pipeline
+          # residue from #197), so every non-main run warned about it.
           path: |
             website/content
             website/last-sync.json
-            website/translation-changelog.json
           retention-days: 14
           if-no-files-found: warn
 


### PR DESCRIPTION
The orchestrator pipeline does not produce `website/translation-changelog.json` — it is a legacy-pipeline residue that landed in the upload paths with #197. Every non-main dispatch run emits an `if-no-files-found` warning for it. Drop the path; content + baseline stay in the artifact.

Merging is held until the in-flight stale-catch-up run finishes (keeping main quiet mid-run).

Generated with Qwen Code (40-shotted by Qwen-Coder)