### PR TITLE
fix(orchestrator): quarantine failed translations before build; gate YAML frontmatter

### DIFF
--- a/.github/workflows/daily-translate.yml
+++ b/.github/workflows/daily-translate.yml
@@ -171,6 +171,25 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.TRANSLATE_CODING_PLAN_API_KEY }}
           OPENAI_BASE_URL: ${{ vars.TRANSLATE_BASE_URL || 'https://coding.dashscope.aliyuncs.com/v1' }}
 
+      # advance wrote per-language .failed.txt quarantine lists. Broken files
+      # must be restored to HEAD BEFORE the build: run 31115350719 proved
+      # that a single verify-evading broken file fails `npm run build`,
+      # which skips the commit step and discards the whole run's good
+      # translations (#185). Restoring early keeps the build green; the
+      # failed files simply stay in the backlog for the next run. The commit
+      # step repeats the same restore as a safety net.
+      - name: Quarantine failed translations before build
+        if: steps.detect.outputs.changed == 'true'
+        run: |
+          shopt -s nullglob
+          for fl in website/orchestrator-manifest-*.failed.txt; do
+            while IFS= read -r p; do
+              [ -n "$p" ] || continue
+              git checkout HEAD -- "website/content/$p" 2>/dev/null \
+                || rm -f "website/content/$p"
+            done < "$fl"
+          done
+
       # Runs after the sync has rewritten last-sync.json, so the age reported
       # here reflects this run's outcome. Catches the failure mode a
       # failure()-gated alert cannot: the job goes green but the baseline

--- a/translator/orchestrator/orchestrator.mjs
+++ b/translator/orchestrator/orchestrator.mjs
@@ -501,6 +501,31 @@ function frontmatterClosed(text) {
     .some((l) => l.trim() === "---" || l.trim() === "...");
 }
 
+/**
+ * Cheap structural sanity check of the frontmatter YAML, without a YAML
+ * parser: every non-empty, non-indented line must open a mapping entry
+ * (`key:`) or a list item (`- `). An unindented bare-text line (typically
+ * a wrapped description) is exactly what fails the site build with
+ * "YAMLParseError: Unexpected scalar token" — run 31115350719. Indented
+ * continuation lines are left alone. False positives are safe: the file
+ * just stays in the backlog and gets retried.
+ */
+function frontmatterYamlish(text) {
+  const lines = text.split("\n");
+  if (lines[0].trim() !== "---") return false;
+  for (let i = 1; i < lines.length; i++) {
+    const l = lines[i];
+    const t = l.trim();
+    if (t === "---" || t === "...") return true;
+    if (t === "") continue;
+    if (/^\s/.test(l)) continue; // indented continuation
+    if (/^[^\s:][^:]*:(\s|$)/.test(l)) continue; // key: value
+    if (/^-(\s|$)/.test(l)) continue; // list item
+    return false;
+  }
+  return false; // no closing delimiter
+}
+
 function verifyFile(lang, f, manifest) {
   const rel = relInContent(f);
   const enPath = path.join(OPTS.contentDir, "en", rel);
@@ -529,8 +554,12 @@ function verifyFile(lang, f, manifest) {
     problems.push(
       `code fence mismatch (en=${fenceCount(en)} ${lang}=${fenceCount(tg)})`
     );
-  if (hasFrontmatter(en) && (!hasFrontmatter(tg) || !frontmatterClosed(tg)))
-    problems.push("frontmatter missing/unclosed");
+  if (hasFrontmatter(en)) {
+    if (!hasFrontmatter(tg) || !frontmatterClosed(tg))
+      problems.push("frontmatter missing/unclosed");
+    else if (!frontmatterYamlish(tg))
+      problems.push("frontmatter not parseable YAML");
+  }
   const linksEn = (en.match(/\]\(/g) || []).length;
   const linksTg = (tg.match(/\]\(/g) || []).length;
   if (linksEn !== linksTg)


### PR DESCRIPTION
Run [31115350719](https://github.com/QwenLM/qwen-code-docs/actions/runs/31115350719) translated all 390 stale-catch-up files, then died at `Build website`: one pt-BR file whose frontmatter was structurally closed but **invalid YAML** (`YAMLParseError: Unexpected scalar token` — an unindented wrapped description) slipped past the verify gate. Quarantine only happened at commit time — after the build — so the failed build skipped the commit and **discarded all 270 verify-passed translations**.

Two fixes, closing the #185 failure class:

1. **Quarantine before build** — a new step restores verify-failed files to HEAD right after advance, so broken output can never fail the build. Failed files simply stay in the backlog for the next run. The commit step keeps its existing restore as a safety net.
2. **YAML frontmatter gate** — `frontmatterYamlish()`: every non-indented frontmatter line must open a mapping entry (`key:`) or list item (`- `). Catches the wrapped-bare-text shape that breaks YAML parsing; indented continuations pass. False positives are safe (file stays in backlog, retried next run).

Verified: `node --check`, workflow YAML parse, and three heuristic test cases (broken shape rejected — exact YAMLParseError shape from the failed run; quoted/indented/list frontmatter accepted).

Also observed in the failed run, for follow-up: the de agent exited almost immediately (1/65 files written) and zh/fr/ru each skipped ~14 files ('target not touched this session') — agent exits are swallowed by `|| true` and never alert. Not addressed here; needs separate handling.

Generated with Qwen Code (40-shotted by Qwen-Coder)