### PR TITLE
fix(orchestrator): chunked agent dispatch; hard no-shell rule in prompt

### DIFF
--- a/translator/orchestrator/orchestrator.mjs
+++ b/translator/orchestrator/orchestrator.mjs
@@ -423,6 +423,42 @@ function renderPrompt(lang, batch) {
     .replaceAll("{{FILES}}", files);
 }
 
+// One agent session per chunk, not one session per language: the CLI's
+// loop detection kills an entire session on one blocked/retried tool call
+// (runs 31115350719/31119970640 lost de almost entirely that way). Chunks
+// bound the blast radius of a halted session.
+const TRANSLATE_CHUNK = 15;
+
+// --safe-mode is read-only (no write/edit tools), so the agent could never
+// write translations. auto-edit approves read/write/edit (shell stays
+// gated), which matches the prompt's "do not run builds or commands".
+async function runAgent(lang, prompt, logSuffix) {
+  const args = ["--approval-mode", "auto-edit", "-p", prompt, "-o", "text"];
+  if (OPTS.model) args.push("--model", OPTS.model);
+  const log = path.join(
+    path.dirname(manifestPath(lang)),
+    `orchestrator-agent-${lang}${logSuffix}.log`
+  );
+  // Stream agent output live (CI step log + runner-side log file) instead
+  // of capturing it: a 20-file batch ran tens of minutes silent otherwise.
+  const fd = fs.openSync(log, "w");
+  const child = spawn("qwen", args, {
+    cwd: ROOT,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  child.stdout.on("data", (c) => {
+    process.stdout.write(c);
+    fs.writeSync(fd, c);
+  });
+  child.stderr.on("data", (c) => {
+    process.stderr.write(c);
+    fs.writeSync(fd, c);
+  });
+  const status = await new Promise((resolve) => child.on("close", resolve));
+  fs.closeSync(fd);
+  return { status, log };
+}
+
 async function cmdTranslate(lang) {
   // Parallel per-language dispatches share .temp-source-repo; serialize
   // ensure+hash so concurrent fetch/reset cannot trip git locks or hash a
@@ -446,38 +482,33 @@ async function cmdTranslate(lang) {
     files: batch.map((b) => ({ file: b.file, hash: b.hash })),
   };
   fs.writeFileSync(manifestPath(lang), JSON.stringify(manifest, null, 2));
-  const prompt = renderPrompt(lang, batch);
-  console.log(
-    `[orch] ${lang}: dispatching agent for ${batch.length} file(s)...`
-  );
-  // --safe-mode is read-only (no write/edit tools), so the agent could never
-  // write translations. auto-edit approves read/write/edit (shell stays
-  // gated), which matches the prompt's "do not run builds or commands".
-  const args = ["--approval-mode", "auto-edit", "-p", prompt, "-o", "text"];
-  if (OPTS.model) args.push("--model", OPTS.model);
-  const log = path.join(
-    path.dirname(manifestPath(lang)),
-    `orchestrator-agent-${lang}.log`
-  );
-  // Stream agent output live (CI step log + runner-side log file) instead
-  // of capturing it: a 20-file batch ran tens of minutes silent otherwise.
-  const fd = fs.openSync(log, "w");
-  const child = spawn("qwen", args, {
-    cwd: ROOT,
-    stdio: ["ignore", "pipe", "pipe"],
-  });
-  child.stdout.on("data", (c) => {
-    process.stdout.write(c);
-    fs.writeSync(fd, c);
-  });
-  child.stderr.on("data", (c) => {
-    process.stderr.write(c);
-    fs.writeSync(fd, c);
-  });
-  const status = await new Promise((resolve) => child.on("close", resolve));
-  fs.closeSync(fd);
-  console.log(`[orch] ${lang}: agent exit=${status} (log: ${log})`);
-  if (status !== 0) process.exitCode = 1;
+  const chunks = [];
+  for (let i = 0; i < batch.length; i += TRANSLATE_CHUNK)
+    chunks.push(batch.slice(i, i + TRANSLATE_CHUNK));
+  let part = 0;
+  for (const chunk of chunks) {
+    part++;
+    const suffix = chunks.length > 1 ? `-part${part}` : "";
+    console.log(
+      `[orch] ${lang}: dispatching agent for ${chunk.length} file(s)` +
+        (chunks.length > 1 ? ` (part ${part}/${chunks.length})...` : "...")
+    );
+    const { status, log } = await runAgent(
+      lang,
+      renderPrompt(lang, chunk),
+      suffix
+    );
+    console.log(`[orch] ${lang}: agent exit=${status} (log: ${log})`);
+    if (status !== 0) {
+      // The workflow's `|| true` keeps the step alive; surface the failure
+      // in the run summary anyway, and leave the chunk's files in the
+      // backlog (verify fails them; they are retried next run).
+      console.log(
+        `::warning::${lang}: agent exited ${status} on part ${part}/${chunks.length}; its files stay in the backlog`
+      );
+      process.exitCode = 1;
+    }
+  }
 }
 
 // ---------- structural gate ----------

--- a/translator/orchestrator/prompts/translate.md
+++ b/translator/orchestrator/prompts/translate.md
@@ -1,4 +1,4 @@
-You are the {{LANG}} translator for the qwen-code documentation site. You have tool access (read, write, edit, grep). Work through EVERY file listed at the bottom, one at a time, in order.
+You are the {{LANG}} translator for the qwen-code documentation site. Your only tools are file tools (read, write, edit, grep) — there is no shell. Work through EVERY file listed at the bottom, one at a time, in order.
 
 For each file (relative path `<rel>`):
 - English source: {{CONTENT_DIR}}/en/<rel>
@@ -10,7 +10,7 @@ Rules:
 3. Terminology: read {{GLOSSARY}} first and follow it. For a term not in it, grep {{CONTENT_DIR}}/{{LANG}}/ for how existing docs render it and follow the majority. When you coin a new term, append a `- term → rendering` line to {{GLOSSARY}}.
 4. Style: follow {{STYLE}}.
 5. Always write the target file, even when the edit is small, so its modification time advances.
-6. Do not run builds or other commands. Do not touch any file outside the list, except the glossary.
+6. NEVER call run_shell_command or any other shell/exec/terminal tool — such calls are rejected in this session, and retrying them terminates the whole session. Do not run builds. Do not touch any file outside the list, except the glossary.
 
 Files to translate (relative to the content dir):
 {{FILES}}


### PR DESCRIPTION
Runs [31115350719](https://github.com/QwenLM/qwen-code-docs/actions/runs/31115350719) and [31119970640](https://github.com/QwenLM/qwen-code-docs/actions/runs/31119970640) lost almost all of de (1/65, then 3/65). Root cause from the logs: the agent occasionally calls `run_shell_command` despite the prompt; the call is rejected in non-interactive mode; the model retries the identical call; the CLI's loop detection halts the whole session (`Loop detection halted the run (consecutive_identical_tool_calls…)`). With one session per language, one halted session wiped the whole language.

Two changes:

1. **Chunked dispatch** — one agent session per 15-file chunk instead of one session per language (65 files → 5 chunks: 15,15,15,15,5). A halted session now loses at most 15 files; they stay in the backlog (verify fails them) and retry next run. Chunk failures surface as `::warning::` annotations instead of being swallowed.
2. **Prompt hardening** — states explicitly that the agent has no shell and that calling shell tools terminates the session.

Verified: `node --check`, chunk-split arithmetic. Manifest/baseline flow unchanged (one manifest per language, written before dispatch; advance re-verifies all files regardless of which chunk produced them).

Generated with Qwen Code (41-shotted by Qwen-Coder)