### PR TITLE
fix(orchestrator): preflight the translation credential before any work

### DIFF
--- a/.github/workflows/daily-translate.yml
+++ b/.github/workflows/daily-translate.yml
@@ -140,6 +140,17 @@ jobs:
           grep -oE 'backlog [A-Za-z-]+: [1-9][0-9]*' /tmp/orch-detect.log \
             | awk '{print $2}' | tr -d ':' > /tmp/orch-langs.txt || true
 
+      # Fail fast on a dead credential (#189): one minimal completion request
+      # before any real work. A dead key used to cost a full multi-hour run
+      # that ended in thousands of per-file errors instead of a 5-second stop.
+      - name: Preflight translation credentials
+        if: steps.detect.outputs.changed == 'true'
+        working-directory: ./translator/orchestrator
+        env:
+          OPENAI_API_KEY: ${{ secrets.TRANSLATE_CODING_PLAN_API_KEY }}
+          OPENAI_BASE_URL: ${{ vars.TRANSLATE_BASE_URL || 'https://coding.dashscope.aliyuncs.com/v1' }}
+        run: node orchestrator.mjs preflight
+
       # Installs BEFORE translation on purpose: the agent runs auto-edit over
       # the whole checkout, so a malicious translation could modify
       # website/package.json. If `npm ci` ran after translation, it would

--- a/translator/orchestrator/orchestrator.mjs
+++ b/translator/orchestrator/orchestrator.mjs
@@ -717,11 +717,61 @@ function cmdAdvance(lang) {
   );
 }
 
+// ---------- preflight ----------
+
+/**
+ * Validate the translation credential in seconds, before hours of agent
+ * work: a dead key used to surface as thousands of per-file translation
+ * errors at the end of the run (#189). One minimal completion request;
+ * any non-2xx or network failure exits non-zero so the workflow step
+ * fails fast.
+ */
+async function cmdPreflight() {
+  const base = (
+    process.env.OPENAI_BASE_URL || "https://coding.dashscope.aliyuncs.com/v1"
+  ).replace(/\/+$/, "");
+  const key = process.env.OPENAI_API_KEY;
+  if (!key) {
+    console.log("::error::preflight: OPENAI_API_KEY is not set.");
+    process.exit(1);
+  }
+  const model = OPTS.model || process.env.QWEN_MODEL || "qwen3.7-plus";
+  try {
+    const res = await fetch(`${base}/chat/completions`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${key}`,
+      },
+      body: JSON.stringify({
+        model,
+        messages: [{ role: "user", content: "ping" }],
+        max_tokens: 1,
+      }),
+      signal: AbortSignal.timeout(30000),
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      console.log(
+        `::error::preflight: HTTP ${res.status} from ${base}: ${text.slice(0, 300)}`
+      );
+      process.exit(1);
+    }
+    console.log(`[orch] preflight: credentials OK (${model} @ ${base})`);
+  } catch (err) {
+    console.log(`::error::preflight: ${err.message}`);
+    process.exit(1);
+  }
+}
+
 // ---------- main ----------
 
 switch (cmd) {
   case "detect":
     cmdDetect();
+    break;
+  case "preflight":
+    await cmdPreflight();
     break;
   case "sync-en":
     cmdSyncEn();
@@ -740,7 +790,7 @@ switch (cmd) {
     break;
   default:
     console.log(
-      "usage: orchestrator.mjs <detect|sync-en|seed|translate|verify|advance> [--lang L] [--limit N] [--content-dir D] [--baseline B] [--manifest M] [--langs csv]"
+      "usage: orchestrator.mjs <detect|preflight|sync-en|seed|translate|verify|advance> [--lang L] [--limit N] [--content-dir D] [--baseline B] [--manifest M] [--langs csv]"
     );
     process.exitCode = cmd ? 1 : 0;
 }


### PR DESCRIPTION
Fixes #189. A dead key used to cost a full multi-hour run: the 07-29..08-03 run series each dispatched every agent, failed every file, and ended in thousands of per-file errors before anyone could tell the credential was the problem.

- New `preflight` subcommand in `orchestrator.mjs`: one minimal completion request against the configured endpoint (`OPENAI_BASE_URL` + `OPENAI_API_KEY`). Any non-2xx or network failure exits non-zero with a clear `::error::` in ~5s.
- New workflow step `Preflight translation credentials`, gated on `changed == 'true'`, running right after detect — before dependency installs and translation.

Verified locally: syntax, workflow YAML, and the failure paths (missing key / fake key → `HTTP 401 … invalid access token`, exit 1, ~1s). The success path runs with the real CI key once merged.

Merging is held until the in-flight ko first-translation run finishes (keeping main quiet mid-run).

Generated with Qwen Code (47-shotted by Qwen-Coder)