### PR TITLE
fix(orchestrator): read target languages from translation.config.json (ko was silently skipped)

### DIFF
--- a/translator/orchestrator/glossary.ko.md
+++ b/translator/orchestrator/glossary.ko.md
@@ -1,0 +1,19 @@
+# Glossary (ko)
+
+English term → Korean rendering. Follow existing entries; append new ones as `- term → rendering` when you coin a term.
+
+- hook → hook（번역하지 않음）
+- skill → skill（번역하지 않음）
+- subagent → 서브에이전트
+- sandbox → 샌드박스
+- checkpoint → 체크포인트
+- slash command → 슬래시 명령어
+- headless → 헤드리스 모드
+- approval mode → 승인 모드
+- embedding host → 임베딩 호스트
+- unattached session → 연결되지 않은 세션
+- session picker → 세션 선택기
+- model context protocol → 모델 컨텍스트 프로토콜
+- retrieval-augmented generation → 검색 증강 생성
+- tool call → 도구 호출
+- context window → 컨텍스트 창

--- a/translator/orchestrator/orchestrator.mjs
+++ b/translator/orchestrator/orchestrator.mjs
@@ -38,14 +38,44 @@ const ROOT = path.resolve(HERE, "../..");
 const { positional, flags } = parseFlags(process.argv.slice(2));
 const cmd = positional[0];
 
+/**
+ * Target languages come from website/translation.config.json — the same
+ * source the legacy sync pipeline and the website itself read — so adding
+ * a locale there (e.g. ko via #181) reaches the orchestrator too. The old
+ * hardcoded default silently kept ko out of every detect/translate run:
+ * the baseline never gained ko entries and the backlog never listed them.
+ */
+function configTargetLangs(contentDir) {
+  try {
+    const cfg = JSON.parse(
+      fs.readFileSync(
+        path.join(contentDir, "..", "translation.config.json"),
+        "utf8"
+      )
+    );
+    if (Array.isArray(cfg.targetLanguages) && cfg.targetLanguages.length)
+      return cfg.targetLanguages.map(String);
+  } catch {
+    // Missing/unreadable config: fall back to the historical list.
+  }
+  return ["zh", "de", "fr", "ja", "ru", "pt-BR"];
+}
+
+const CONTENT_DIR = path.resolve(
+  ROOT,
+  flags["content-dir"] || "website/content"
+);
+
 const OPTS = {
   repo: flags.repo || "https://github.com/QwenLM/qwen-code.git",
   branch: flags.branch || "main",
   docsPath: flags["docs-path"] || "docs",
-  contentDir: path.resolve(ROOT, flags["content-dir"] || "website/content"),
+  contentDir: CONTENT_DIR,
   baseline: path.resolve(ROOT, flags.baseline || "website/last-sync.json"),
   tempDir: path.resolve(ROOT, flags["temp-dir"] || ".temp-source-repo"),
-  langs: String(flags.langs || "zh,de,fr,ja,ru,pt-BR").split(","),
+  langs: flags.langs
+    ? String(flags.langs).split(",")
+    : configTargetLangs(CONTENT_DIR),
   limit: flags.limit ? parseInt(flags.limit, 10) : Infinity,
   model: flags.model || null,
 };


### PR DESCRIPTION
#181 wired `ko` into `translation.config.json` and the website, but the orchestrator hardcoded its language list as `zh,de,fr,ja,ru,pt-BR` (and the workflow never passes `--langs`). Result: **every detect/translate run silently skipped ko** — no ko backlog listed, no ko baseline entries, dispatch runs translated the other six languages and never touched Korean (see run 31141432038: no `backlog ko` line at all).

- `langs` now defaults from `website/translation.config.json` (`targetLanguages`) — the same source the legacy pipeline and the website read. The hardcoded list remains only as a fallback for a missing config.
- Adds a seed `glossary.ko.md` (standard term set) so the translate prompt's glossary reference resolves for ko.

Verified locally: `node --check` + a real `detect` run against upstream HEAD now prints `backlog ko: 115` (ko was previously absent from the output).

Merging promptly so the follow-up dispatch can translate the ko backlog.

Generated with Qwen Code (49-shotted by Qwen-Coder)