### PR TITLE
fix(ci): build-deploy must check out the moving main tip, not the pinned SHA

### DIFF
--- a/.github/workflows/daily-translate.yml
+++ b/.github/workflows/daily-translate.yml
@@ -301,9 +301,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
-          # Fresh checkout of main, which now INCLUDES the translations the
-          # translate job just committed (#184: build and translate no longer
-          # share a working tree, so a build failure can never touch them).
+          # ref: main is load-bearing: without it, checkout resolves
+          # github.sha — the commit PINNED when the workflow was
+          # triggered — which predates the translations the translate
+          # job committed mid-run. Run 31142844576 deployed exactly
+          # this stale tree (gh-pages "deploy: 72cffb8" while main was
+          # already at a0a5fd4), leaving every new translation
+          # unpublished until the NEXT run. Checking out the moving
+          # branch tip picks up the translate job's commit.
+          ref: main
           fetch-depth: 0
           filter: blob:none
 


### PR DESCRIPTION
Follow-up to #208's split, caught by the first split run [31142844576](https://github.com/QwenLM/qwen-code-docs/actions/runs/31142844576).

## The bug

The build-deploy job's `actions/checkout` had no `ref`, so it resolved `github.sha` — the commit **pinned when the workflow was triggered** — not the branch tip. The translate job pushes its commit mid-run, after that pin. Result: the build ran on the PRE-translation tree.

Evidence from the first run:
- translate job committed `a0a5fd4` (94 ko pages) at 04:48 UTC, job green
- build-deploy job green, but gh-pages received **`deploy: 72cffb8`** (main as of the 02:57 trigger, no ko)
- all `/ko/...` pages 404 after a fully green run

Left unfixed, **every nightly run would deploy yesterday's content** — the site permanently one day behind.

## The fix

`ref: main` on the build-deploy checkout: the job checks out the branch tip at job start, which includes the translate job's commit. One-line change; comment in the YAML documents why it's load-bearing.

Verified: workflow YAML parses.

⚠️ **Please review and merge before tonight's 20:00 UTC cron** — otherwise tonight's run deploys today's content one day late again. (The 05:02 manual dispatch works around it for the ko content specifically, because its pinned SHA already includes the ko commit.)

Generated with Qwen Code (60-shotted by Qwen-Coder)