### PR TITLE
chore(template): sync nextra-template locale lists with the supported language set

### DIFF
--- a/translator/nextra-template/app/[lang]/layout.tsx
+++ b/translator/nextra-template/app/[lang]/layout.tsx
@@ -14,6 +14,8 @@ const i18n_maps = [
   { locale: "ru", name: "Русский" },
   { locale: "ja", name: "日本語" },
   { locale: "es", name: "Español" },
+  { locale: "pt-BR", name: "Português (BR)" },
+  { locale: "ko", name: "한국어" },
 ];
 
 const i18n = i18n_maps.filter((lang) => {

--- a/translator/nextra-template/asset-prefix.mjs
+++ b/translator/nextra-template/asset-prefix.mjs
@@ -1,5 +1,5 @@
 const GITHUB_PAGE_PREFIX = "qwen-code-docs";
-export const locales = ["en", "zh", "de", "fr", "ru", "ja", "es"];
+export const locales = ["en", "zh", "de", "fr", "ru", "ja", "es", "pt-BR", "ko"];
 
 export const getAssetPrefix = () => {
   const isProduction = process.env.NODE_ENV === "production";

--- a/translator/nextra-template/src/components/custom-navbar.tsx
+++ b/translator/nextra-template/src/components/custom-navbar.tsx
@@ -8,6 +8,7 @@ import { GitHubIcon, DiscordIcon } from "nextra/icons";
 import { Button } from "nextra/components";
 import { FileText, Star, BookOpen } from "lucide-react";
 import { ThemeToggle } from "./theme-toggle";
+import { locales } from "../../asset-prefix.mjs";
 
 // 定义接口类型
 interface NavbarProps {
@@ -70,6 +71,18 @@ const useGitHubStars = (repoUrl?: string) => {
   return { stars, loading };
 };
 
+// 浏览器语言前缀 -> 站点 locale
+const BROWSER_LANG_MAP: Record<string, string> = {
+  zh: "zh",
+  de: "de",
+  fr: "fr",
+  ru: "ru",
+  ja: "ja",
+  es: "es",
+  pt: "pt-BR",
+  ko: "ko",
+};
+
 // 获取用户语言的函数
 const getUserLanguage = (): string => {
   if (typeof window === "undefined") return "en";
@@ -80,22 +93,15 @@ const getUserLanguage = (): string => {
 
   if (pathSegments.length > 0) {
     const possibleLang = pathSegments[0];
-    const supportedLanguages = ["en", "zh", "de", "fr", "ru", "ja", "es", "pt-BR", "ko"];
-    if (supportedLanguages.includes(possibleLang)) {
+    if (locales.includes(possibleLang)) {
       return possibleLang;
     }
   }
 
   // 如果URL中没有语言信息，使用浏览器语言
   const browserLang = navigator.language.toLowerCase();
-  if (browserLang.startsWith("zh")) return "zh";
-  if (browserLang.startsWith("de")) return "de";
-  if (browserLang.startsWith("fr")) return "fr";
-  if (browserLang.startsWith("ru")) return "ru";
-  if (browserLang.startsWith("ja")) return "ja";
-  if (browserLang.startsWith("es")) return "es";
-  if (browserLang.startsWith("pt")) return "pt-BR";
-  if (browserLang.startsWith("ko")) return "ko";
+  const matched = BROWSER_LANG_MAP[browserLang.split("-")[0]];
+  if (matched && locales.includes(matched)) return matched;
 
   return "en"; // 默认英文
 };

--- a/translator/nextra-template/src/components/custom-navbar.tsx
+++ b/translator/nextra-template/src/components/custom-navbar.tsx
@@ -80,7 +80,7 @@ const getUserLanguage = (): string => {
 
   if (pathSegments.length > 0) {
     const possibleLang = pathSegments[0];
-    const supportedLanguages = ["en", "zh", "de", "fr", "ru", "ja"];
+    const supportedLanguages = ["en", "zh", "de", "fr", "ru", "ja", "es", "pt-BR", "ko"];
     if (supportedLanguages.includes(possibleLang)) {
       return possibleLang;
     }
@@ -93,6 +93,9 @@ const getUserLanguage = (): string => {
   if (browserLang.startsWith("fr")) return "fr";
   if (browserLang.startsWith("ru")) return "ru";
   if (browserLang.startsWith("ja")) return "ja";
+  if (browserLang.startsWith("es")) return "es";
+  if (browserLang.startsWith("pt")) return "pt-BR";
+  if (browserLang.startsWith("ko")) return "ko";
 
   return "en"; // 默认英文
 };

--- a/translator/nextra-template/src/components/language-dropdown.tsx
+++ b/translator/nextra-template/src/components/language-dropdown.tsx
@@ -14,6 +14,8 @@ const languages_maps = [
   { locale: "ru", name: "Русский", flag: "🇷🇺" },
   { locale: "ja", name: "日本語", flag: "🇯🇵" },
   { locale: "es", name: "Español", flag: "🇪🇸" },
+  { locale: "pt-BR", name: "Português (BR)", flag: "🇧🇷" },
+  { locale: "ko", name: "한국어", flag: "🇰🇷" },
 ];
 
 const languages = languages_maps.filter((lang) => {


### PR DESCRIPTION
## What

Brings the `translator/nextra-template` scaffold's locale surfaces in line with the language set the translator actually supports (`languageNames` in `translator/src/translator.ts`): adds **pt-BR** and **ko**, and fixes an internal inconsistency where **es** was present in `asset-prefix.mjs` but missing from the navbar's own hardcoded list, so Spanish browsers were never auto-detected on scaffolded sites.

Follow-up to #181, whose notes intentionally left the template out ("the scaffold's locale lists are already out of sync with the live site … refreshing them belongs in a separate PR").

## Changes

| File | Change |
|---|---|
| `asset-prefix.mjs` | `locales` += `pt-BR`, `ko` — the single list that `next.config.mjs`, the layout and the dropdown all filter against |
| `app/[lang]/layout.tsx` | `i18n_maps` += `Português (BR)`, `한국어` |
| `src/components/language-dropdown.tsx` | `languages_maps` += 🇧🇷 `Português (BR)`, 🇰🇷 `한국어` |
| `src/components/custom-navbar.tsx` | `supportedLanguages` += `es`, `pt-BR`, `ko`; browser-language detection for `es` / `pt` / `ko` |

Names and flags match the live site's `website/src/components/language-dropdown.tsx`.

## Notes

- The template is copied verbatim by `translator/src/cli.ts` on `init`, so this is what new scaffolded sites start from. As before, a scaffolded site that wants fewer languages trims the one `locales` array in `asset-prefix.mjs` — the layout and dropdown maps already filter through it.
- `content/` starters (`en`, `zh` only) are untouched — same as the existing behaviour for `es`, nothing renders for a locale until the translator produces content for it.
- Verified `asset-prefix.mjs` still parses (`node -e "import(...)"` → `en,zh,de,fr,ru,ja,es,pt-BR,ko`); the `.tsx` changes are data-only additions to existing literal arrays.
