### PR TITLE
fix(website): include ko in the layout LOCALES allowlist

### DIFF
--- a/website/app/[lang]/layout.tsx
+++ b/website/app/[lang]/layout.tsx
@@ -22,7 +22,7 @@ type LayoutProps = Readonly<{
   }>;
 }>;
 
-const LOCALES = ["en", "zh", "de", "fr", "ru", "ja", "pt-BR"];
+const LOCALES = ["en", "zh", "de", "fr", "ru", "ja", "pt-BR", "ko"];
 
 const LanguageLayout: FC<LayoutProps> = async ({ children, params }) => {
   const { lang } = await params;


### PR DESCRIPTION
## Root cause

`website/app/[lang]/layout.tsx` gates every `/[lang]/**` route on a hardcoded `LOCALES` array and calls `notFound()` for anything missing. `ko` was absent, so **every Korean route prerendered as a 404 page** — while the build stayed green (prerendering succeeds; the output just embeds the 404 UI) and the deployed pages returned HTTP 200 with a `This page could not be found` body. That made the ko launch look successful from status codes and even from raw-HTML greps (the RSC flight payload still serializes the Korean MDX), while browsers correctly showed 404.

`ko` is already wired everywhere else: `next.config.mjs` i18n.locales, `app/sitemap.ts`, the page route's own LOCALES (`page.jsx`), `locale-anchor.tsx`, `custom-navbar.tsx`, `structured-data.ts`, `translation.config.json`, and the i18n dropdown 79 lines below the buggy array in this same file — which is why the switcher offers 한국어 and then lands on a 404.

## Fix

One-line allowlist addition. After merge, the push-triggered `deploy-docs.yml` rebuilds and the 113 existing ko pages render for real.

## Known follow-ups (not in this PR)

1. **No `_meta.ts` under content/ko/** (0 vs 17 per other locale) — Nextra falls back to an auto-generated alphabetical sidebar with raw filenames. The translator has `qwen-translation meta` (translator/src/meta-translator.ts) to generate them; needs an API credential run.
2. **`/ko/blog/` and `/ko/showcase/` will 404** — 41 blog posts + showcase untranslated (50 EN pages without ko counterparts). `mobile-menu.tsx` hardcodes `/${lang}/blog` and `/${lang}/showcase` for every locale, so the Korean mobile nav links into 404s. Content-pipeline backlog, worth a tracking issue.

Credit: root cause identified by an independent analysis (Claude); this PR implements the same one-line fix.

Generated with Qwen Code (84-shotted by Qwen-Coder)