### PR TITLE
fix(i18n): self-heal frontmatter mismatches

### DIFF
--- a/translator/orchestrator/orchestrator.mjs
+++ b/translator/orchestrator/orchestrator.mjs
@@ -578,15 +578,32 @@ function hasFrontmatter(text) {
   return text.startsWith("---\n");
 }
 
-function frontmatterClosed(text) {
-  const lines = text.split("\n");
-  if (lines[0].trim() !== "---") return false;
+function frontmatterBlock(text) {
+  if (!hasFrontmatter(text)) return null;
   // No line cap: a doc with long frontmatter must not fail the gate
   // forever (retried daily, never advancing). Scanning the whole file
   // is cheap next to the translation that produced it.
-  return lines
-    .slice(1)
-    .some((l) => l.trim() === "---" || l.trim() === "...");
+  return (
+    text.match(/^---\n[\s\S]*?^[ \t]*(?:---|\.\.\.)[ \t]*(?:\n|$)/m)?.[0] ??
+    null
+  );
+}
+
+function frontmatterClosed(text) {
+  return frontmatterBlock(text) !== null;
+}
+
+function normalizeFrontmatter(source, target) {
+  const sourceFrontmatter = frontmatterBlock(source);
+  const targetFrontmatter = frontmatterBlock(target);
+  if (hasFrontmatter(target) && !targetFrontmatter) return target;
+  if (!hasFrontmatter(source))
+    return targetFrontmatter ? target.slice(targetFrontmatter.length) : target;
+  if (!sourceFrontmatter) return target;
+  return (
+    sourceFrontmatter +
+    (targetFrontmatter ? target.slice(targetFrontmatter.length) : target)
+  );
 }
 
 /**
@@ -715,14 +732,16 @@ function verifyFile(lang, f, manifest) {
   // The mtime gate must see the file as the agent left it: stat BEFORE the
   // self-heal below, whose write would otherwise refresh mtime and let a
   // stale (pre-session) translation pass as "touched this session".
-  const touchedThisSession =
-    fs.statSync(target).mtimeMs >= manifest.createdAt;
+  const targetStat = fs.statSync(target);
+  const touchedThisSession = targetStat.mtimeMs >= manifest.createdAt;
   // Self-heal: translation agents sometimes drop the "./" on relative links
   // (GitHub renders bare paths; webpack resolves them as modules and fails).
   // Repair at the gate so stale on-disk files never break the build.
-  const healed = normalizeRelativeLinks(tg);
+  const healed = normalizeFrontmatter(en, normalizeRelativeLinks(tg));
   if (healed !== tg) {
     fs.writeFileSync(target, healed);
+    if (!touchedThisSession)
+      fs.utimesSync(target, targetStat.atime, targetStat.mtime);
     tg = healed;
   }
   if (!touchedThisSession) problems.push("target not touched this session");

--- a/translator/src/orchestrator.test.ts
+++ b/translator/src/orchestrator.test.ts
@@ -47,6 +47,56 @@ test("rejects target-only frontmatter", () => {
   }
 });
 
+test("self-heals closed target-only frontmatter without refreshing a stale file", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "qwen-orchestrator-test-"));
+  const contentDir = path.join(root, "content");
+  const manifest = path.join(root, "manifest.json");
+  const target = path.join(contentDir, "zh", "commands.md");
+
+  try {
+    fs.mkdirSync(path.join(contentDir, "en"), { recursive: true });
+    fs.mkdirSync(path.join(contentDir, "zh"), { recursive: true });
+    fs.writeFileSync(path.join(contentDir, "en", "commands.md"), "# Commands\n");
+    fs.writeFileSync(target, "---\ntitle: Commands\n---\n# 命令\n");
+    const stale = new Date("2000-01-01T00:00:00Z");
+    fs.utimesSync(target, stale, stale);
+    fs.writeFileSync(
+      manifest,
+      JSON.stringify({ createdAt: Date.now(), files: ["docs/commands.md"] })
+    );
+
+    const verify = () =>
+      spawnSync(
+        process.execPath,
+        [
+          orchestrator,
+          "verify",
+          "--lang",
+          "zh",
+          "--content-dir",
+          contentDir,
+          "--manifest",
+          manifest,
+        ],
+        { encoding: "utf8" }
+      );
+
+    for (let i = 0; i < 2; i++) {
+      const result = verify();
+      assert.equal(result.status, 1, result.stdout || result.stderr);
+      assert.match(result.stdout, /target not touched this session/);
+    }
+    assert.equal(fs.readFileSync(target, "utf8"), "# 命令\n");
+    assert.equal(fs.statSync(target).mtimeMs, stale.getTime());
+
+    fs.utimesSync(target, new Date(), new Date());
+    const result = verify();
+    assert.equal(result.status, 0, result.stdout || result.stderr);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("quarantine keeps a sound replacement over corrupt HEAD", () => {
   const root = fs.realpathSync(
     fs.mkdtempSync(path.join(os.tmpdir(), "qwen-quarantine-test-"))


### PR DESCRIPTION
## Summary

Before this change, a translated page with target-only frontmatter failed verification forever: the prompt preserved the existing block, verification rejected it, and quarantine had no sound revision to restore.

This change makes the shared verification gate copy or remove frontmatter to match the English source before structural validation. Self-heal writes preserve the original mtime for stale files, so a second verification cannot mistake an old translation for work produced in the current run.

## Reviewer Test Plan

- `cd translator && npx tsx --test src/orchestrator.test.ts`
- `cd translator && npm run build`
- `cd translator && node --check orchestrator/orchestrator.mjs`

UI verification: N/A (translation pipeline logic only).

Fixes #216
