### PR TITLE
fix(i18n): repair stray frontmatter opener

### DIFF
--- a/translator/orchestrator/orchestrator.mjs
+++ b/translator/orchestrator/orchestrator.mjs
@@ -768,7 +768,13 @@ function frontmatterClosed(text) {
 function normalizeFrontmatter(source, target) {
   const sourceFrontmatter = frontmatterBlock(source);
   const targetFrontmatter = frontmatterBlock(target);
-  if (hasFrontmatter(target) && !targetFrontmatter) return target;
+  if (hasFrontmatter(target) && !targetFrontmatter) {
+    // The bot has emitted this exact source-absent stray opener in otherwise
+    // valid Markdown. General malformed YAML stays untouched for quarantine.
+    if (!hasFrontmatter(source) && target.startsWith("---\n\n"))
+      return target.slice(5);
+    return target;
+  }
   if (!hasFrontmatter(source))
     return targetFrontmatter ? target.slice(targetFrontmatter.length) : target;
   if (!sourceFrontmatter) return target;

--- a/translator/src/orchestrator.test.ts
+++ b/translator/src/orchestrator.test.ts
@@ -7,7 +7,7 @@ import { test } from "node:test";
 
 const orchestrator = path.resolve(__dirname, "../orchestrator/orchestrator.mjs");
 
-test("rejects target-only frontmatter", () => {
+test("self-heals a stray target-only frontmatter opener", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "qwen-orchestrator-test-"));
   const contentDir = path.join(root, "content");
   const manifest = path.join(root, "manifest.json");
@@ -40,8 +40,12 @@ test("rejects target-only frontmatter", () => {
       { encoding: "utf8" }
     );
 
-    assert.equal(result.status, 1, result.stdout || result.stderr);
-    assert.match(result.stdout, /FAIL zh commands\.md.*frontmatter mismatch/);
+    assert.equal(result.status, 0, result.stdout || result.stderr);
+    assert.match(result.stdout, /PASS zh commands\.md/);
+    assert.equal(
+      fs.readFileSync(path.join(contentDir, "zh", "commands.md"), "utf8"),
+      "# 命令\n"
+    );
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }

--- a/website/content/ko/developers/sdk-typescript.md
+++ b/website/content/ko/developers/sdk-typescript.md
@@ -1,5 +1,3 @@
----
-
 # Typescript SDK
 
 ## @qwen-code/sdk


### PR DESCRIPTION
## Summary

- remove the stray `---` opener currently committed in the Korean TypeScript SDK page
- self-heal only the exact source-absent `---\n\n` shape at the shared verification boundary
- keep general malformed frontmatter quarantined and preserve the existing mtime/touched-session semantics

## Verification

- `npx tsx --test src/orchestrator.test.ts src/orchestrator-security.test.ts` (8/8)
- `node --check translator/orchestrator/orchestrator.mjs`
- Korean and English TypeScript SDK fence counts both equal 0
- `git diff --check`

Follow-up to #216.