### PR TITLE
fix(i18n): retry transient preflight failures

### DIFF
--- a/translator/orchestrator/orchestrator.mjs
+++ b/translator/orchestrator/orchestrator.mjs
@@ -1438,31 +1438,43 @@ async function cmdPreflight() {
     process.exit(1);
   }
   const model = OPTS.model || process.env.QWEN_MODEL || "qwen3.7-plus";
-  try {
-    const res = await fetch(`${base}/chat/completions`, {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        authorization: `Bearer ${key}`,
-      },
-      body: JSON.stringify({
-        model,
-        messages: [{ role: "user", content: "ping" }],
-        max_tokens: 1,
-      }),
-      signal: AbortSignal.timeout(30000),
-    });
-    if (!res.ok) {
-      const text = await res.text().catch(() => "");
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    try {
+      const res = await fetch(`${base}/chat/completions`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${key}`,
+        },
+        body: JSON.stringify({
+          model,
+          messages: [{ role: "user", content: "ping" }],
+          max_tokens: 1,
+        }),
+        signal: AbortSignal.timeout(30000),
+      });
+      if (!res.ok) {
+        const text = await res.text().catch(() => "");
+        const message = `HTTP ${res.status} from ${base}: ${text.slice(0, 300)}`;
+        if (res.status !== 429 && res.status < 500) {
+          console.log(`::error::preflight: ${message}`);
+          process.exit(1);
+        }
+        throw new Error(message);
+      }
+      console.log(`[orch] preflight: credentials OK (${model} @ ${base})`);
+      return;
+    } catch (err) {
+      const cause = err.cause?.code ? ` (${err.cause.code})` : "";
+      if (attempt === 3) {
+        console.log(`::error::preflight: ${err.message}${cause}`);
+        process.exit(1);
+      }
       console.log(
-        `::error::preflight: HTTP ${res.status} from ${base}: ${text.slice(0, 300)}`
+        `::warning::preflight attempt ${attempt}/3 failed: ${err.message}${cause}; retrying...`
       );
-      process.exit(1);
+      await new Promise((resolve) => setTimeout(resolve, attempt * 1000));
     }
-    console.log(`[orch] preflight: credentials OK (${model} @ ${base})`);
-  } catch (err) {
-    console.log(`::error::preflight: ${err.message}`);
-    process.exit(1);
   }
 }
 

--- a/translator/src/orchestrator-preflight.test.ts
+++ b/translator/src/orchestrator-preflight.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import http from "node:http";
+import path from "node:path";
+import { test } from "node:test";
+
+const orchestrator = path.resolve(__dirname, "../orchestrator/orchestrator.mjs");
+
+test("preflight retries a transient network failure", async () => {
+  let requests = 0;
+  const server = http.createServer((req, res) => {
+    requests++;
+    if (requests === 1) {
+      req.socket.destroy();
+      return;
+    }
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end("{}");
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+
+  try {
+    const address = server.address();
+    assert(address && typeof address === "object");
+    const child = spawn(
+      process.execPath,
+      [orchestrator, "preflight", "--model", "test-model"],
+      {
+        env: {
+          ...process.env,
+          OPENAI_API_KEY: "test-key",
+          OPENAI_BASE_URL: `http://127.0.0.1:${address.port}`,
+        },
+      }
+    );
+    let output = "";
+    child.stdout.on("data", (chunk) => (output += chunk));
+    child.stderr.on("data", (chunk) => (output += chunk));
+    const status = await new Promise<number | null>((resolve) =>
+      child.on("close", resolve)
+    );
+
+    assert.equal(status, 0, output);
+    assert.equal(requests, 2);
+    assert.match(output, /attempt 1\/3 failed.*retrying/);
+    assert.match(output, /credentials OK/);
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+});


### PR DESCRIPTION
## Summary

- retry preflight network failures, HTTP 429, and HTTP 5xx responses up to three bounded attempts
- keep authentication and other HTTP 4xx errors fail-fast
- include the underlying network cause code in warnings and the final error

## Verification

- `npm test` (translator): 18 tests passed
- `npm run build` (translator)
- new local-server regression test drops the first connection and proves the second attempt succeeds
- `node --check translator/orchestrator/orchestrator.mjs`
- `git diff --check`

Closes #227.