### PR TITLE
fix: make structured translation sessions reliable

### DIFF
--- a/translator/orchestrator/orchestrator.mjs
+++ b/translator/orchestrator/orchestrator.mjs
@@ -33,6 +33,7 @@
 import { execSync, spawn } from "node:child_process";
 import crypto from "node:crypto";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -469,8 +470,9 @@ function renderPrompt(lang, batch) {
   return { documents, prompt };
 }
 
-// Bound one failed agent session to five files instead of a whole language.
-const TRANSLATE_CHUNK = 5;
+// Keep prompt size bounded: source + existing target for one large doc can
+// already approach the model context limit.
+const TRANSLATE_CHUNK = 1;
 
 // Retry once; repeated failures stay in the next run's backlog.
 const TRANSLATE_ATTEMPTS = 2;
@@ -527,6 +529,18 @@ function parseStructuredResult(stdout) {
     return message.structured_result;
   }
   throw new Error("qwen JSON output omitted a result message");
+}
+
+function qwenErrorMessage(stdout) {
+  try {
+    const messages = JSON.parse(stdout);
+    if (!Array.isArray(messages)) return null;
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i]?.type === "result" && messages[i].is_error)
+        return messages[i].error?.message || null;
+    }
+  } catch {}
+  return null;
 }
 
 function applyTranslationPatches(lang, documents, result) {
@@ -613,9 +627,10 @@ function applyTranslationPatches(lang, documents, result) {
 // The trusted parent validates and applies exact patches under one locale.
 async function runAgent(lang, request, logSuffix) {
   const args = [
-    "--safe-mode",
     "--auth-type",
     "openai",
+    "--core-tools",
+    "structured_output",
     "--max-tool-calls",
     "0",
     "--system-prompt",
@@ -631,8 +646,10 @@ async function runAgent(lang, request, logSuffix) {
     `orchestrator-agent-${lang}${logSuffix}.log`
   );
   const fd = fs.openSync(log, "w");
+  const agentHome = fs.mkdtempSync(path.join(os.tmpdir(), "qwen-translate-"));
   const child = spawn("qwen", args, {
-    cwd: ROOT,
+    cwd: agentHome,
+    env: { ...process.env, HOME: agentHome, XDG_CONFIG_HOME: agentHome },
     stdio: ["pipe", "pipe", "pipe"]
   });
   let stdout = "";
@@ -647,6 +664,7 @@ async function runAgent(lang, request, logSuffix) {
   child.stdin.on("error", () => {}); // child exit is reported by its status below
   child.stdin.end(request.prompt);
   let status = await new Promise((resolve) => child.on("close", resolve));
+  fs.rmSync(agentHome, { recursive: true, force: true });
   if (status === 0) {
     try {
       applyTranslationPatches(
@@ -657,6 +675,13 @@ async function runAgent(lang, request, logSuffix) {
     } catch (err) {
       status = 1;
       const message = `[orch] rejected structured output: ${err.message}\n`;
+      process.stderr.write(message);
+      fs.writeSync(fd, message);
+    }
+  } else {
+    const error = qwenErrorMessage(stdout);
+    if (error) {
+      const message = `[orch] qwen error: ${error}\n`;
       process.stderr.write(message);
       fs.writeSync(fd, message);
     }
@@ -721,7 +746,7 @@ async function cmdTranslate(lang) {
       if (attempt < TRANSLATE_ATTEMPTS) {
         // Re-dispatches the whole chunk, including any file the halted
         // attempt already translated. That redundancy is what keeps this
-        // simple, and at TRANSLATE_CHUNK=5 it is cheap; verify's "touched
+        // simple, and with one file per session it is cheap; verify's "touched
         // this session" check is satisfied by the rewrite either way.
         console.log(
           `[orch] ${lang}: part ${part}/${chunks.length} failed; retrying once...`
@@ -1082,7 +1107,7 @@ function cmdAdvance(lang) {
     (rec.langs ??= {})[lang] = hash ?? current;
     advanced++;
   }
-  saveBaseline(base, commit);
+  if (advanced > 0) saveBaseline(base, commit);
   // Quarantine list for the workflow's commit step: verify-failed files must
   // be restored/removed before staging, or broken output gets deployed.
   fs.writeFileSync(failedListPath(lang), failed.length ? failed.join("\n") + "\n" : "");

--- a/translator/src/orchestrator-security.test.ts
+++ b/translator/src/orchestrator-security.test.ts
@@ -23,6 +23,7 @@ test("translation agent has no general tools and cannot write undeclared paths",
   const fakeBin = path.join(root, "bin");
   const fakeQwen = path.join(fakeBin, "qwen");
   const target = path.join(contentDir, "zh", "guide.md");
+  const baseline = path.join(project, "website", "last-sync.json");
 
   try {
     fs.mkdirSync(path.join(upstream, "docs"), { recursive: true });
@@ -59,11 +60,12 @@ test("translation agent has no general tools and cannot write undeclared paths",
       `#!/usr/bin/env node
 const fs = require("node:fs");
 const args = process.argv.slice(2);
-for (const flag of ["--safe-mode", "--auth-type", "--json-schema", "--max-tool-calls", "--system-prompt"])
+for (const flag of ["--auth-type", "--core-tools", "--json-schema", "--max-tool-calls", "--system-prompt"])
   if (!args.includes(flag)) process.exit(20);
-if (args.includes("--approval-mode") || args[args.indexOf("--auth-type") + 1] !== "openai" || args[args.indexOf("--max-tool-calls") + 1] !== "0") process.exit(21);
+if (args.includes("--approval-mode") || args[args.indexOf("--auth-type") + 1] !== "openai" || args[args.indexOf("--core-tools") + 1] !== "structured_output" || args[args.indexOf("--max-tool-calls") + 1] !== "0") process.exit(21);
 const prompt = fs.readFileSync(0, "utf8");
 if (!prompt.includes("# Guide") || prompt.includes("sentinel-secret")) process.exit(22);
+if (process.cwd().includes(${JSON.stringify(project)}) || process.env.HOME === ${JSON.stringify(process.env.HOME)}) process.exit(23);
 const path = process.env.FAKE_ESCAPE === "1" ? "../../outside.md" : "guide.md";
 const payload = { translations: [{ path, replacements: [{ old: "旧内容。", new: "新内容。" }] }] };
 process.stdout.write(JSON.stringify([{ type: "result", is_error: false, structured_result: payload }]));
@@ -85,7 +87,7 @@ process.stdout.write(JSON.stringify([{ type: "result", is_error: false, structur
       "--content-dir",
       contentDir,
       "--baseline",
-      path.join(project, "website", "last-sync.json"),
+      baseline,
       "--temp-dir",
       path.join(root, "source-clone"),
       "--manifest",
@@ -108,6 +110,15 @@ process.stdout.write(JSON.stringify([{ type: "result", is_error: false, structur
     assert.match(rejected.stderr, /unexpected or duplicate translation path/);
     assert.equal(fs.readFileSync(target, "utf8"), "# 指南\n新内容。\n");
     assert.equal(fs.existsSync(path.join(root, "outside.md")), false);
+
+    const advance = spawnSync(
+      process.execPath,
+      [copiedOrchestrator, "advance", ...args.slice(2)],
+      { encoding: "utf8", env }
+    );
+    assert.equal(advance.status, 0, advance.stdout || advance.stderr);
+    assert.match(advance.stdout, /advanced 0\/1/);
+    assert.equal(fs.existsSync(baseline), false);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

- expose only the schema-backed `structured_output` tool to each Qwen translation session
- isolate Qwen from repository and user configuration, and bound each session to one document
- surface structured CLI errors and avoid advancing the baseline when no file passed verification

## Verification

- `npm test` (18 tests passed)
- `npm run build`
- `node --check translator/orchestrator/orchestrator.mjs`
- `git diff --check`

Refs #201.