### PR TITLE
docs: finish pending Chinese translation backlog

### DIFF
--- a/website/content/zh/developers/qwen-serve-protocol.md
+++ b/website/content/zh/developers/qwen-serve-protocol.md
@@ -13,6 +13,8 @@ Authorization: Bearer <token>
 
 如果未配置 token（环回开发的默认情况），则该 header 是可选的。Token 比较采用恒定时间算法。对于 `missing header` / `wrong scheme` / `wrong token`，401 响应格式是统一的。
 
+**`--open-with-auth`。** 这个默认关闭的 CLI 模式要求使用环回绑定且 Web Shell 可用。它复用正常的 `--token` 优先于 `QWEN_SERVER_TOKEN` 的选择；如果两者都为空，则会在 daemon 启动前生成 32 个随机字节并编码为 base64url。浏览器通过 `#token=` 接收所选 bearer 并按标签页保存；协议和中间件看到的只是一个普通的已配置 token。单独使用 `--open`、直接嵌入的调用者、非环回绑定和其他客户端都不会获得自动凭据。浏览器不可用的环境会输出带有密钥片段的 URL，供手动打开。环回 `/health` 和 Web Shell 静态资源保留下文所述的豁免；`--require-auth` 仍会保护 `/health`。
+
 **`/health` 豁免**（Bctum）：在环回绑定（`127.0.0.1` / `localhost` / `::1` / `[::1]`）上，`/health` 在 bearer 中间件之前注册，因此即使守护进程使用 `--token` 启动，pod 内的存活探针（liveness probes）也无需携带 token。非环回绑定（如 `--hostname 0.0.0.0`）会像其他所有路由一样将 `/health` 置于 bearer 验证之后——有关基本原理，请参阅 [`GET /health`](#get-health) 部分。
 
 **`--require-auth`（#4175 PR 15）。** 在启动时传递此标志，可将"必须具有 token"的规则扩展到环回绑定。如果没有 token，启动将失败；同时取消 `/health` 豁免（因此 `/health` 也需要 `Authorization: Bearer …`）。
@@ -211,6 +213,7 @@ OPTIONS 预检请求（带有 `Access-Control-Request-Method` 或 `Access-Contro
  'workspace_display_name',
  'workspace_qualified_rest_core', 'workspace_qualified_voice',
  'workspace_qualified_memory', 'extension_management_v2', 'extension_git_credentials',
+ 'extension_local_path_install',
  'workspace_persisted_transcript',
  'workspace_session_export', 'workspace_archived_session_export',
  'workspace_session_live_state',
@@ -253,7 +256,7 @@ OPTIONS 预检请求（带有 `Access-Control-Request-Method` 或 `Access-Contro
 
 `session_organization` 宣告了自定义会话分组和置顶功能。它新增了 `GET/POST/PATCH/DELETE /workspace/:id/session-groups`、`PATCH /session/:id/organization`，以及可选的有序列表视图 `GET /workspace/:id/sessions?view=organized`。当同时通告了 `session_organization` 和 `workspace_qualified_rest_core` 时，workspace 限定的组织变更 `PATCH /workspaces/:workspace/session/:id/organization` 也可用。旧版变更路由仍然仅限主 workspace。旧版 daemon 对变更/分组路由返回 `404`，并忽略有序视图契约，因此 WebShell/SDK 客户端在显示分组或置顶 UI 前，必须预先检查这些 tag。
 
-`session_archive` 宣告了 v1 目录状态归档 API：`POST /sessions/archive`、`POST /sessions/unarchive` 和 `GET /workspace/:id/sessions?archiveState=active|archived`。归档的会话在取消归档前无法被加载或恢复。
+`session_archive` 宣告了 v1 目录状态归档 API：`POST /sessions/archive`、`POST /sessions/unarchive` 和 `GET /workspace/:id/sessions?archiveState=active|archived`。归档的会话在取消归档前无法被加载或恢复。`session_storage_conflict_repair` 宣告下文所述的增量 `resolveConflicts` 请求选项和 `resolvedConflicts` 响应分组。
 
 `workspace_qualified_rest_core` 通告 `/workspaces/:workspace/...` 下的复数核心 REST 路由。选择器首先解析为精确的 workspace id，然后解析为规范化后的 URL 编码绝对 cwd。较新的单 workspace daemon 即使在 `multi_workspace_sessions` 缺失时也会在 `workspaces[]` 中包含主 runtime，以便客户端可以发现 workspace 限定路由所需的 id；客户端应对省略该数组的旧版 daemon 回退到 `capabilities.workspaceCwd`。信任状态和信任请求路由可用于已注册的不受信任的 workspace；文件读取路由遵循现有的文件系统读取策略。已注册的不受信任的次要 workspace 还暴露仅持久化的 session 和 session-group 目录：这些读取不会附加到 session、启动 ACP 或合并活跃 bridge 状态。文件写入、目录变更和其他复数核心路由需要受信任的 workspace，除非单独的能力明确定义了更窄的只读策略，例如 `workspace_persisted_transcript`。不受信任的主 workspace 仍然会从复数目录和转录路由收到 `403 { code: "untrusted_workspace" }`；旧版单数主路由保持其现有的兼容行为。此标签涵盖核心文件、状态、设置、权限、信任、生命周期、MCP 控制、工具和 skill 切换、memory、workspace agent CRUD 和 session 存储暴露面。它不涵盖 auth、voice、extensions、ACP/WebSocket 传输、channel-worker 路由或 workspace 限定的 session 导出；请单独预检 `workspace_session_export` 或 `workspace_archived_session_export`。Workspace 信任不是 ACL：持有 daemon token 的客户端可以读取此策略允许的每个已注册 workspace 暴露面。
 
@@ -282,6 +285,8 @@ OPTIONS 预检请求（带有 `Access-Control-Request-Method` 或 `Access-Contro
 `extension_management_v2` 通告用户级 extension 目录和 `/extensions/*` 的变更暴露面，以及 `/workspaces/:workspace/extensions/*` 的 workspace 激活投影。制品是全局的；workspace 路由仅暴露投影读取、精确的激活覆盖和 runtime 刷新。读取可以针对不受信任的已注册 workspace，而激活、刷新和 workspace 作用域的安装需要受信任的目标。慢速变更使用 `/extensions/operations/:operationId` 的 daemon 本地操作；存储代（store generation），而非操作历史，在重启和跨 daemon 间具有权威性。已发布的 `workspace_extensions` 能力和 `/workspace/extensions/*` 路由保留为主 workspace 兼容适配器。客户端必须预检 `extension_management_v2`，不得从 daemon 模式或 `workspace_qualified_rest_core` 推断它。
 
 `extension_git_credentials` 在 `POST /workspace/extensions/install` 和 `POST /extensions/install` 上通告经过认证的 HTTPS Git 安装。客户端在发送 URL userinfo 或 `credentialPersistence` 前必须预检此标签；旧版 daemon 会拒绝 URL 凭证。该标签描述的是后端协议支持，而非密钥链的可用性：stored 模式在终端操作结果中报告所选后端。
+
+`extension_local_path_install` 在 `POST /workspace/extensions/install` 和 `POST /extensions/install` 上通告 daemon 本地的 Extension 源。`source` 必须是 daemon 主机上实际存在的绝对路径。相对路径仍不受支持，以免 daemon 进程 cwd 改变源的身份，或遮蔽 GitHub `owner/repo` 简写。现有安装操作会将 Extension 复制到托管存储，而不是链接源目录。客户端必须预检此标签，因为旧版 daemon 会拒绝本地源。
 
 `extension_batch_activation_v2` 新增 `PUT /extensions/activation` 和 `PUT /workspaces/:workspace/extensions/activation`。两者接受 `extensionNames` 中的 1–100 个名称，以不区分大小写的方式去重同时保留首次出现的顺序，在一代中持久化变更的目标，并返回一个 `202` 操作句柄。设置 `enabled` 或 `disabled` 时目标无需已安装：其名称会创建一个期望状态声明，当安装同名 Extension 时该声明会被保留。全局路由接受 `state: "enabled" | "disabled"`，写入 V2 `defaultActivation`，并调和每个已注册的 runtime。workspace 路由还接受 `"inherit"`，为选定的受信任 runtime 应用或清除精确覆盖，并仅调和该 runtime。`inherit` 不会为未知名称创建声明；全未知清除报告 `updated: false` 并跳过调和。单数激活路由保持为仅已安装且按 id 寻址。
 
@@ -366,7 +371,7 @@ workspace 投影响应为：
 }
 ```
 
-对于仅 workspace 的初始激活，使用 `{ "scope": "workspace", "workspaceId": "target-workspace-id" }`；目标必须存在且受信任。Daemon 安装接受 GitHub、Git 和 npm 源。`ref` 不适用于 npm，`registry` 仅适用于 npm。`ref`、`autoUpdate`、`allowPreRelease` 和 `registry` 是可选的。
+对于仅 workspace 的初始激活，使用 `{ "scope": "workspace", "workspaceId": "target-workspace-id" }`；目标必须存在且受信任。Daemon 安装接受 GitHub、Git 和 npm 源。当通告 `extension_local_path_install` 时，也接受 daemon 主机上实际存在的绝对路径。`ref` 不适用于 npm，`ref` 和 `autoUpdate` 不适用于本地源，`registry` 仅适用于 npm。`ref`、`autoUpdate`、`allowPreRelease` 和 `registry` 是可选的。
 
 当 `extension_git_credentials` 被通告时，HTTPS Git 源可以包含 userinfo，例如 `https://username:token@git.example.com/org/repository.git`。`credentialPersistence` 仅对此类源有效。它为 `stored` 或 `one_time`，省略时默认为 `one_time`。Stored 模式通过 daemon 的混合密钥存储保存凭证，并仅在安装元数据中保留干净的仓库 URL，因此 extension 保持可更新。One-time 模式既不保存仓库 URL 也不保存凭证，并创建一个不可更新的 `snapshot`；此模式下 `autoUpdate: true` 会被拒绝。在没有 URL 凭证的情况下提供该字段、提供无效凭证，或对 npm、归档、本地、SSH 或非 Git 源使用凭证，都会返回 `400`。
 
@@ -474,6 +479,7 @@ Workspace 限定的变更使用相同的全局 `/extensions/operations/:operatio
 | `session_shell_command`             | 明确启用了会话 shell 执行。                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 | `session_artifacts_persistence`     | session 制品持久化已为 runtime 连接。                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | `session_generation`                | session 生成助手可用。                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| `scheduled_task_session_reuse`      | 持久化 scheduled task session 管理处于活动状态，且每个托管 daemon runtime 都已安装回调，使任务可以显式绑定到其当前已有的 session。                                                                                                                                                                                                                                                                                                                                                              |
 | `workspace_generation`              | workspace 作用域的生成助手可用。                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | `rate_limit`                        | 启用了 `--rate-limit` / `QWEN_SERVE_RATE_LIMIT=1` / `ServeOptions.rateLimit`。                                                                                                                                                                                                                                                                                                                                                                                                                               |
 | `workspace_reload`                  | 嵌入式路由配置中提供了工作区重载支持。                                                                                                                                                                                                                                                                                                                                                                                                                                      |
@@ -2091,7 +2097,7 @@ Response:
 请求：
 
 ```json
-{ "sessionIds": ["<uuid>"] }
+{ "sessionIds": ["<uuid>"], "resolveConflicts": true }
 ```
 
 响应：
@@ -2122,12 +2128,15 @@ Response:
 {
   "archived": ["<uuid>"],
   "alreadyArchived": [],
+  "resolvedConflicts": ["<uuid>"],
   "notFound": [],
   "errors": []
 }
 ```
 
-`errors` 条目格式为 `{ "sessionId": "<uuid>", "error": "message" }`。具有相同 id 的 active 和 archived 文件会被视为冲突并报告在 `errors` 中；不会覆盖任何文件。
+`resolveConflicts` 是可选项，默认为 `false`。默认情况下，如果 active 和 archived 文件具有相同 id，冲突会报告在 `errors` 中，两个副本都不会被移动、删除或覆盖。归档活跃 session 时，仍会在判定冲突前执行上文所述的严格关闭，因此关闭操作可能会将排队记录刷新到 active 转录中。设置 `resolveConflicts: true` 后，归档会保留 archived 副本、移除 active 副本，并在 `archived` 和 `resolvedConflicts` 中同时报告该 id。`errors` 条目格式为 `{ "sessionId": "<uuid>", "error": "message" }`。
+
+生命周期冲突是批处理中单个条目的结果：无 workspace 和 workspace 限定路由都会返回 HTTP `200`，并将冲突放在 `errors` 中。这取代了早先 workspace 限定路由的 HTTP `409 session_conflict` 信封；调用该路由的客户端必须检查批处理响应。内部 runtime 的 REST 批处理继续隐藏其他逐 session 失败的详细信息，同时保留安全的冲突消息。
 
 ### `POST /sessions/unarchive`
 
@@ -2136,7 +2145,7 @@ Response:
 请求：
 
 ```json
-{ "sessionIds": ["<uuid>"] }
+{ "sessionIds": ["<uuid>"], "resolveConflicts": true }
 ```
 
 响应：
@@ -2145,12 +2154,13 @@ Response:
 {
   "unarchived": ["<uuid>"],
   "alreadyActive": [],
+  "resolvedConflicts": ["<uuid>"],
   "notFound": [],
   "errors": []
 }
 ```
 
-如果该 id 已存在 active 的 JSONL 文件，取消归档会在 `errors` 中报告冲突且不会覆盖它。如果同一个 id 正在进行归档或取消归档操作，会在开始批处理前返回 `409 session_archiving`。
+`resolveConflicts` 是可选项，默认为 `false`。默认情况下，同时存在 active 和 archived JSONL 文件会在 `errors` 中产生冲突，两个副本都不会被移动、删除或覆盖；仅有 active 副本的 session 会返回在 `alreadyActive` 中。设置 `resolveConflicts: true` 后，取消归档会保留 active 副本、移除 archived 副本，并在 `unarchived` 和 `resolvedConflicts` 中同时报告该 id。如果同一个 id 正在进行归档或取消归档操作，会在开始批处理前返回 `409 session_archiving`。
 
 ACP-over-HTTP 通过 vendor 方法 `_qwen/sessions/archive` 和 `_qwen/sessions/unarchive` 使用相同的请求和响应体。REST 路由表将 `POST /sessions/archive` 和 `POST /sessions/unarchive` 映射到 ACP 传输的这些方法。
 
@@ -2707,19 +2717,20 @@ SSE 级别的 `id:` / `event:` 行复制了 `envelope.id` / `envelope.type`，�
 
 > **F3 (#4175)：多客户端权限协调。** F3 添加了上述四种策略。F3 之前的 daemon 硬编码了 first-responder；当配置的策略为 `first-responder` 时，线路格式保持逐位不变。新事件（`permission_partial_vote`、`permission_forbidden`）是增量添加的 — 旧 SDK 会将它们视为 `unrecognized_known_event` 并优雅地忽略。
 
-> **权限超时（默认 5 分钟）。** `permission_request`
+> **权限超时（默认禁用）。** `permission_request`
 > 保持挂起状态，直到：(a) 某个客户端在此处投票，(b) 触发 `POST /session/:id/cancel`
 > 触发，(c) 驱动提示词的 HTTP 客户端断开连接
 > （中途取消会将未决的权限解析为 `cancelled`），
 > (d) session 被终止，(e) daemon 关闭，**或
-> (f) 触发每个 session 的权限超时**（`DEFAULT_PERMISSION_TIMEOUT_MS`，
-> 5 分钟）。超时触发时，agent 的 `requestPermission` 解析
+> (f) 触发已配置的超时**。超时触发时，agent 的 `requestPermission` 解析
 > 为 `{outcome: 'cancelled'}`，审计 ring 记录一条
 > `permission.timeout` 条目，daemon stderr 输出一行
 > 提示信息，并且 SSE 总线扇出标准的
 > `permission_resolved` cancelled 帧，以便订阅者进行清理。
-> 超时时间可通过 `BridgeOptions.permissionResponseTimeoutMs` 配置；
-> 运行长提示词的无头调用者可能需要延长此时间。
+> 共享超时时间可通过 `BridgeOptions.permissionResponseTimeoutMs` 或
+> `qwen serve --permission-response-timeout-ms` 配置。默认值为 `0`，因此普通权限和
+> `ask_user_question` 都会无限期等待人工决定。投票者取消、session 取消、
+> 断开连接清理和 daemon 关闭仍会将挂起的交互解析为 cancelled。
 
 请求：
 

--- a/website/content/zh/developers/tools/task.md
+++ b/website/content/zh/developers/tools/task.md
@@ -16,9 +16,9 @@
 - `fork_turns`（字符串，可选）：仅在 `subagent_type="fork"` 时有效。省略或使用 `all` 继承完整的父会话上下文，或使用正整数字符串（如 `"3"`）继承最近三个真实用户轮次。工具响应和纯系统提醒不计入轮次。
 - `fork_tools`（字符串数组，可选）：仅在 `subagent_type="fork"` 时有效。将执行限制为精确的规范工具名称或 MCP 服务器模式，同时保持 fork 当前对模型可见的工具声明不变以共享 prompt 缓存。条目不能包含前后空白；通配符仅限于 `mcp__*` 或尾部 MCP 工具前缀模式（如 `mcp__github__read_*`）。Fork 永远不会执行 `ask_user_question`；省略 `fork_tools` 以允许所有其他继承的工具，或使用空数组拒绝所有工具调用。
 - `fork_profile`（字符串，可选）：仅在 `subagent_type="fork"` 时有效。从活动项目根目录加载一个仅含 frontmatter 的普通 `.qwen/fork-profiles/<name>.md` 文件（最大 64 KiB），并应用其必需的 `tools` 数组以及可选的最多 200 个字符的 `promptHint`。该文件不能解析到项目 profile 目录之外。`fork_profile` 不能与 `fork_tools` 或命名的 teammate 组合使用，且在安全模式或裸模式下不可用。
-- `run_in_background`（布尔值，可选）：默认为 `true`（针对顶层常规代理）。设置为 `false` 以同步等待常规代理的结果。无头 fork 始终在后台运行。嵌套代理在前台运行，除非 `run_in_background` 显式为 `true`（这会被拒绝，因为嵌套代理无法接收后台完成通知）。调用者拥有的 `working_dir` 启动在前台运行，并拒绝显式或配置的后台执行。
+- `run_in_background`（布尔值，可选）：默认为 `true`（针对顶层常规代理）。设置为 `false` 以同步等待常规代理的结果。无头 fork 始终在后台运行。嵌套代理在前台运行，除非 `run_in_background` 显式为 `true`（这会被拒绝，因为嵌套代理无法接收后台完成通知）。未命名且由调用者拥有 `working_dir` 的启动会在前台运行：显式的 `run_in_background: true` 请求会被拒绝；配置的后台默认值（subagent 定义中的 `background: true`）在顶层会被拒绝，在嵌套时则降级为前台运行。
 - `isolation`（字符串，可选）：设置为 `"worktree"` 可在 Qwen Code 创建和管理的隔离 Git worktree 中运行显式命名的非 fork 代理。
-- `working_dir`（字符串，可选）：将显式命名的非 fork 代理固定到当前仓库中已有的已注册 Git worktree。调用者拥有 worktree 的生命周期，因此此模式在前台运行。如果同时提供 `working_dir` 和 `isolation`，则 `working_dir` 优先。
+- `working_dir`（字符串，可选）：将显式命名的非 fork 代理固定到当前仓库中已有的已注册 Git worktree。未命名启动会在前台运行，因为调用者拥有 worktree 的生命周期（参见 `run_in_background`）；固定到该 worktree 的命名队友会并发运行，移除 worktree 前必须先将其关闭。如果同时提供 `working_dir` 和 `isolation`，则 `working_dir` 优先。
 
 ## 如何使用 `agent` 与 Qwen Code
 

--- a/website/content/zh/users/configuration/model-providers.md
+++ b/website/content/zh/users/configuration/model-providers.md
@@ -18,6 +18,43 @@ Qwen Code 允许你通过 `settings.json` 中的 `modelProviders` 设置来配�
 >
 > **模型唯一性：** 同一 `authType` 内的模型通过 `id` + `baseUrl` 的组合进行唯一标识。这意味着你可以在单个 `authType` 下多次定义相同的模型 ID（例如 `"gpt-4o"`），只要每个条目具有不同的 `baseUrl` —— 例如，一个直接指向 OpenAI，另一个指向代理端点。如果两个条目具有相同的 `id` 和相同的 `baseUrl`（或都省略了 `baseUrl`），则第一个出现的条目生效，后续的重复项将被跳过并附带警告。
 
+### 图像生成路由
+
+当某个路由可供内置 `image_gen` 工具使用时，请设置 `supportsImageGeneration: true`。此能力独立于 `capabilities.vision` 或 `generationConfig.modalities.image` 等图像输入支持。
+
+当路由专用于图像生成且不应出现在普通模型选择器中时，请设置 `imageOnly: true`。为保持向后兼容，`imageOnly: true` 也会隐式启用图像生成能力，因此现有设置无需迁移。
+
+双用途路由既可选作主模型，也可通过 `/model --image` 选择：
+
+```json
+{
+  "modelProviders": {
+    "openai": [
+      {
+        "id": "omni-model",
+        "envKey": "MODEL_API_KEY",
+        "baseUrl": "https://gateway.example.com/model-api",
+        "supportsImageGeneration": true
+      }
+    ]
+  }
+}
+```
+
+专用图像路由需要同时设置这两个字段。只包含 `imageOnly: true` 的旧格式仍然有效：
+
+```json
+{
+  "id": "image-model",
+  "envKey": "MODEL_API_KEY",
+  "baseUrl": "https://images.example.com/api/v1",
+  "supportsImageGeneration": true,
+  "imageOnly": true
+}
+```
+
+所选路由必须声明明确的 HTTPS `baseUrl` 和非空 `envKey`。图像生成使用该路由相同的端点和凭据；如果聊天与图像生成需要不同的端点或凭据，请配置两个路由。
+
 ## 各 Auth Type 的配置示例
 
 以下是针对不同认证类型的全面配置示例，展示了可用的参数及其组合。
@@ -33,6 +70,9 @@ Qwen Code 允许你通过 `settings.json` 中的 `modelProviders` 设置来配�
 | `gemini`     | Google Gemini API                                                                                                                             |
 | `qwen-oauth` | Qwen OAuth（硬编码，无法在 `modelProviders` 中覆盖）                                                                                          |
 | `vertex-ai`  | Google Vertex AI（在 Vertex AI 模式下使用 `gemini` 协议和 `@google/genai` SDK；选择它会设置 `GOOGLE_GENAI_USE_VERTEXAI=true`）                |
+
+> [!note]
+> Vertex AI 条目可以使用 **Application Default Credentials** 进行认证。设置 `GOOGLE_CLOUD_PROJECT`（以及可选的 `GOOGLE_CLOUD_LOCATION`，默认为 `global`），并让 `envKey` 以及解析器读取的所有其他密钥来源保持未设置：`GOOGLE_API_KEY`、`settings.security.auth.apiKey` 和 CLI 密钥参数。任何传入 Vertex 条目的 API key 都会使 Google SDK 切换到 Vertex Express 模式，从而忽略项目、区域和 ADC 凭据。声明了 `envKey` 的条目绝不会转而使用 ADC，因此变量注入失败后会继续针对该变量报错，而不会静默改用其他主体进行认证。
 
 > [!warning]
 > 既不是内置协议也未通过 `providerProtocol` 映射的 provider id（例如拼写错误如 `"openai-custom"`）无法被路由，因此其整个条目会被**跳过**并附带警告——其模型不会出现在 `/model` 选择器中。内置 provider 请使用上面列出的受支持 auth type 值之一，自定义 id 请添加 [`providerProtocol`](#自定义-provider-idproviderprotocol) 映射。
@@ -270,6 +310,7 @@ Qwen Code 使用以下官方 SDK 向各个提供商发送请求：
         "baseUrl": "http://localhost:11434/v1",
         "generationConfig": {
           "timeout": 300000,
+          "streamIdleTimeoutMs": 600000,
           "maxRetries": 1,
           "contextWindowSize": 32768,
           "samplingParams": {
@@ -310,6 +351,8 @@ Qwen Code 使用以下官方 SDK 向各个提供商发送请求：
   }
 }
 ```
+
+对于有排队或响应较慢的本地 OpenAI 兼容服务器，`streamIdleTimeoutMs` 控制所选模型在流式数据块之间最多可保持静默多久。它会覆盖所选 provider 条目的全局 `QWEN_STREAM_IDLE_TIMEOUT_MS` 值；设为 `0` 可禁用空闲保护。除非提高或禁用 `QWEN_STREAM_MAX_LIFETIME_MS`，否则独立的 15 分钟流生命周期上限仍然生效。
 
 对于不需要身份验证的本地服务器，你可以为 API key 使用任何占位符值：
 
@@ -578,9 +621,10 @@ Coding Plan 模型配置具有版本控制。当 Qwen Code 检测到模型模板
 
 | 协议 / provider | 网络请求结构 | 备注 |
 | --- | --- | --- |
-| **OpenAI / DashScope**（`qwen3.8-max` 系列） | 扁平的 `reasoning_effort: <effort>` body 参数 | 五个 `/effort` 级别（`low`、`medium`、`high`、`xhigh`、`max`）对于任何以 `qwen3.8-max` 开头的模型 id（包括带日期的快照和 `-latest` 别名）会原样传递；DashScope 会应用任何模型特定的映射。当 `reasoning_effort` 和 `thinking_budget` 冲突时，正常的 `extra_body` > `samplingParams` > `reasoning` 优先级仅保留更高优先级的字段；显式的同层对保留 `reasoning_effort`，与 provider 在跨层解析之前的行为一致。如果静态字段胜出，`/effort` 会报告该字段而非暗示请求的级别已生效。当 effort 级别胜出时，冲突的 `enable_thinking` 也会被丢弃。`extra_body` 中的显式 `enable_thinking: false` 会被遵从而非丢弃：它会以 `reasoning_effort: 'none'` 覆盖配置的级别，这是 `extra_body` 少数不按原样生效的地方之一。其他 Qwen 模型继续将所选级别映射为 `enable_thinking: true`；`reasoning_effort` 覆盖会在那里原样传递，除非它与 `thinking_budget` 冲突（DashScope 会拒绝该组合），此时无效的 `reasoning_effort` 会被丢弃，`enable_thinking` 和 `thinking_budget` 均保留。 |
-| **OpenAI / DeepSeek** (`api.deepseek.com`) | 扁平的 `reasoning_effort: <effort>` body 参数 | 当在嵌套配置中设置 `reasoning.effort` 时，它会被重写为扁平的 `reasoning_effort`，并且 `'low'`/`'medium'` 会被规范化为 `'high'`，`'xhigh'` 规范化为 `'max'` —— 这反映了 DeepSeek 的[服务端向后兼容](https://api-docs.deepseek.com/zh-cn/api/create-chat-completion)机制。顶层的 `samplingParams.reasoning_effort` 或 `extra_body.reasoning_effort` 覆盖会跳过此规范化并原样发送。 |
-| **OpenAI**（其他兼容服务器） | `reasoning: { effort, ... }` 原样传递 | 当 provider 期望不同的结构时，通过 `samplingParams` 设置（例如 GPT-5/o-series 的 `samplingParams.reasoning_effort`）。 |
+| **OpenAI / DashScope**（`qwen3.8-max` 系列） | 扁平的 `reasoning_effort: <effort>` body 参数 | 对于任何以 `qwen3.8-max` 开头的模型 id（包括带日期的快照和 `-latest` 别名），`/effort` 级别会直接传递；DashScope 会应用模型特定的映射。该系列的级别上限为 `xhigh`，因此配置的 `max` 会被截断为 `xhigh`（记录一次日志），而不是发送后被拒绝。`samplingParams` 或 `extra_body` 中显式设置的 `reasoning_effort` 是原样覆盖值，不会被截断。当 `reasoning_effort` 和 `thinking_budget` 冲突时，正常的 `extra_body` > `samplingParams` > `reasoning` 优先级仅保留更高优先级的字段；显式的同层对保留 `reasoning_effort`，与 provider 在跨层解析之前的行为一致。如果静态字段胜出，`/effort` 会报告该字段，而不会暗示请求的级别已生效。当 effort 级别胜出时，冲突的 `enable_thinking` 也会被丢弃。`extra_body` 中显式的 `enable_thinking: false` 会被遵从而非丢弃：它会以 `reasoning_effort: 'none'` 覆盖配置的级别，这是 `extra_body` 少数不按原样生效的地方之一。其他 Qwen 模型继续将所选级别映射为 `enable_thinking: true`；`reasoning_effort` 覆盖会在那里原样传递，除非它与 `thinking_budget` 冲突（DashScope 会拒绝该组合），此时无效的 `reasoning_effort` 会被丢弃，`enable_thinking` 和 `thinking_budget` 均保留。 |
+| **OpenAI / DeepSeek** (`api.deepseek.com`) | 扁平的 `reasoning_effort: <effort>` body 参数 | 当在嵌套配置中设置 `reasoning.effort` 时，它会被重写为扁平的 `reasoning_effort`，并且 `'low'`/`'medium'` 会被规范化为 `'high'`，`'xhigh'` 规范化为 `'max'` —— 这反映了 DeepSeek 的[服务端向后兼容](https://api-docs.deepseek.com/zh-cn/api/create-chat-completion)机制。顶层的 `samplingParams.reasoning_effort` 或 `extra_body.reasoning_effort` 覆盖会跳过此规范化并原样发送。只有真实的 DeepSeek 主机名才接受 `max`；其他主机上名为 `deepseek` 的模型仍使用通用的 `xhigh` 上限，与重构逻辑本身基于主机名的判断一致。 |
+| **OpenAI / Z.ai** (`z.ai`、`bigmodel.cn`) | 扁平的 `reasoning_effort: <effort>` body 参数 | Z.ai 主机上的 GLM-5.2+ 支持完整级别，包括 `max`，嵌套的 `reasoning.effort` 会被重写为扁平字段。较旧的 GLM id，以及通过任何其他主机访问的 `glm-*` 模型，仍使用通用的 `xhigh` 上限：单凭模型名称无法说明该端点接受什么参数。 |
+| **OpenAI**（其他兼容服务器） | `reasoning: { effort, ... }` 直接传递 | 配置的 `max` 会被截断为 `xhigh`（记录一次日志），因为 `max` 是厂商扩展，而非通用 OpenAI 级别的一部分。当 provider 需要不同结构时，请通过 `samplingParams` 设置（例如 GPT-5/o-series 的 `samplingParams.reasoning_effort`）；显式的 `samplingParams` / `extra_body` 值不会被截断。 |
 | **Anthropic**（真实的 `api.anthropic.com`） | `output_config: { effort }` 加上 `effort-2025-11-24` beta header | 真实的 Anthropic 仅接受 `'low'`/`'medium'`/`'high'`。`'max'` 会被**截断为 `'high'`** 并输出一行 `debugLogger.warn`（每个 generator 一次）；如果你需要最大强度，请将 baseURL 切换为支持该强度的 DeepSeek 兼容端点。 |
 | **Anthropic** (`api.deepseek.com/anthropic`) | 相同的 `output_config: { effort }` + beta header | `'max'` 会原样传递。 |
 | **Gemini** (`@google/genai`) | `thinkingConfig: { includeThoughts: true, thinkingLevel }` | `'low'` → `LOW`，`'high'`/`'max'` → `HIGH`，其他 → `THINKING_LEVEL_UNSPECIFIED`（Gemini 没有 `MAX` 级别）。 |
@@ -591,15 +635,17 @@ Coding Plan 模型配置具有版本控制。当 Qwen Code 检测到模型模板
 
 在 `api.deepseek.com` baseURL 下，OpenAI 管道会发出 DeepSeek V4+ 所需的显式 `thinking: { type: 'disabled' }` 字段 —— 服务端默认值为 `'enabled'`，因此仅仅省略 `reasoning_effort` 仍然会产生思考的延迟/成本。自托管的 DeepSeek 后端（sglang/vllm）和其他 OpenAI 兼容服务器**不会**接收此字段；如果你需要在这些后端上禁用思考，请通过 `samplingParams`/`extra_body` 注入 `thinking: { type: 'disabled' }`（或你的推理框架暴露的任何控制参数）。
 
+在 `openrouter.ai` baseURL 下，禁用推理时，OpenAI 管道会发送 OpenRouter 的 provider 级 `reasoning: { enabled: false }` 字段。其他 OpenAI 兼容服务器不会收到这一 OpenRouter 专用字段；请通过 `samplingParams`/`extra_body` 使用它们各自的原生禁用参数。
+
 ### 与 `samplingParams` 的交互（仅限 OpenAI 兼容）
 
 > [!warning]
 >
-> 当在 OpenAI 兼容 provider 上设置了 `generationConfig.samplingParams` 时，管道会将这些键**原样**发送到网络，并完全跳过单独的 `reasoning` 注入。因此，像 `{ samplingParams: { temperature: 0.5 }, reasoning: { effort: 'max' } }` 这样的配置会在 OpenAI/DeepSeek 请求中静默丢弃 reasoning 字段。
->
-> 如果你设置了 `samplingParams`，请直接将推理控制参数包含在其中 —— 对于 DeepSeek，它是 `samplingParams.reasoning_effort`；对于 GPT-5/o-series，它是 `samplingParams.reasoning_effort`（其扁平字段）或 `samplingParams.reasoning`（嵌套对象）。对于 OpenRouter 和其他 provider，字段名称会有所不同；请查阅 provider 文档。
+> 当在 OpenAI 兼容 provider 上设置了 `generationConfig.samplingParams` 时，管道会将这些键**原样**发送到网络，并完全跳过单独的 `reasoning` 注入。因此，像 `{ samplingParams: { temperature: 0.5 }, reasoning: { effort: 'max' } }` 这样的配置会在 OpenAI/DeepSeek 请求中静默丢弃 reasoning 字段。放在 `samplingParams` 内的 `reasoning` 对象是你自己的值，会原样发送：上述 effort 上限只适用于管道从 `/effort` 注入的级别。
 >
 > DashScope Qwen 模型是一个例外：其 provider 直接读取 `reasoning` 并将其映射为 `reasoning_effort` 或 `enable_thinking`。在 qwen3.8-max 系列上，当网络参数冲突时，provider 特定的 `samplingParams` 字段仍然优先；在旧版 qwen 混合模型上，配置的 effort 级别会折叠为 `enable_thinking: true`，这会覆盖 `samplingParams.enable_thinking` 的值。
+>
+> 如果你设置了 `samplingParams`，请直接将推理控制参数包含在其中 —— 对于 DeepSeek，它是 `samplingParams.reasoning_effort`；对于 GPT-5/o-series，它是 `samplingParams.reasoning_effort`（其扁平字段）或 `samplingParams.reasoning`（嵌套对象）。对于 OpenRouter 和其他 provider，字段名称会有所不同；请查阅 provider 文档。
 >
 > Anthropic 和 Gemini 转换器不受影响 —— 无论是否设置 `samplingParams`，它们始终直接读取 `reasoning.effort`。
 

--- a/website/last-sync.json
+++ b/website/last-sync.json
@@ -1575,7 +1575,7 @@
     },
     "docs/developers/tools/task.md": {
       "langs": {
-        "zh": "2d6b9e85a364719a4b65bacffe5f11dfebf18d8de5250593f7751bd966dc289b",
+        "zh": "c3520a001afc4a8d99413f55302fac46b29b56d1fff9349a078513034bf79396",
         "fr": "c3520a001afc4a8d99413f55302fac46b29b56d1fff9349a078513034bf79396",
         "ja": "c3520a001afc4a8d99413f55302fac46b29b56d1fff9349a078513034bf79396",
         "ru": "c3520a001afc4a8d99413f55302fac46b29b56d1fff9349a078513034bf79396",
@@ -1608,7 +1608,7 @@
     },
     "docs/users/configuration/model-providers.md": {
       "langs": {
-        "zh": "2dea9e61b8ffa38bdaf7f310d5e3bbc48ef3f73922038056a9b440280282bb94",
+        "zh": "42785122f997ad7f140e8eba390fe77bccb1052b02fd2dfe22022a676aaa9e13",
         "fr": "42785122f997ad7f140e8eba390fe77bccb1052b02fd2dfe22022a676aaa9e13",
         "ja": "42785122f997ad7f140e8eba390fe77bccb1052b02fd2dfe22022a676aaa9e13",
         "ru": "42785122f997ad7f140e8eba390fe77bccb1052b02fd2dfe22022a676aaa9e13",
@@ -2029,7 +2029,7 @@
         "ru": "36f57afee0ad5e2d17cb096fddfb62d60a90cd7cb68358923fdea93dd36554ea",
         "pt-BR": "36f57afee0ad5e2d17cb096fddfb62d60a90cd7cb68358923fdea93dd36554ea",
         "de": "36f57afee0ad5e2d17cb096fddfb62d60a90cd7cb68358923fdea93dd36554ea",
-        "zh": "8684fe88a4edf420ff93495e4fd57ec13748e77794f0a0f46f33727d0300d39b",
+        "zh": "36f57afee0ad5e2d17cb096fddfb62d60a90cd7cb68358923fdea93dd36554ea",
         "fr": "36f57afee0ad5e2d17cb096fddfb62d60a90cd7cb68358923fdea93dd36554ea",
         "ja": "36f57afee0ad5e2d17cb096fddfb62d60a90cd7cb68358923fdea93dd36554ea",
         "ko": "36f57afee0ad5e2d17cb096fddfb62d60a90cd7cb68358923fdea93dd36554ea"


### PR DESCRIPTION
## Summary

- translate the three remaining stale Chinese documents against qwen-code `8beaa8d9`
- restore structural parity for `model-providers.md`, including its two newly added code-block pairs
- advance only those three Chinese per-file baselines

The model-generated batch in Actions run 33042566786 was quarantined because none of its structured replacements verified, so this PR applies the small upstream deltas directly. This unblocks final validation for #201 and #216.

## Verification

- orchestrator verify: 3/3 passed
- orchestrator detect against qwen-code `8beaa8d9`: 0 backlog for all 7 target languages
- `npm test`: 1/1 passed
- `NODE_OPTIONS=--max-old-space-size=8192 npm run build`: passed (1382 routes; 1353 Pagefind pages)