### PR TITLE
revert: undo PR #100

### DIFF
--- a/website/content/de/blog/index.mdx
+++ b/website/content/de/blog/index.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Qwen Code Blog: KI-Coding Updates und Praxisguides"
-description: "Lesen Sie den Qwen Code Blog mit wöchentlichen Updates, KI-Coding-Praxis, Feature-Releases und Beispielen für moderne agentic coding Workflows."
+title: "Qwen Code Blog"
+description: "Qwen Code Produktupdates, KI-Programmierpraktiken und reale Anwendungsfälle."
 ---
 
 import { BlogHome } from '@/components/blog-home'

--- a/website/content/en/blog/index.mdx
+++ b/website/content/en/blog/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Qwen Code Blog: AI Coding Updates and Guides"
-description: "Read the Qwen Code blog for weekly product updates, AI coding workflows, feature releases, and practical agentic coding guides for developers."
+description: "Qwen Code product updates, AI coding practices, and real-world use cases."
 ---
 
 import { BlogHome } from '@/components/blog-home'

--- a/website/content/fr/blog/index.mdx
+++ b/website/content/fr/blog/index.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Blog Qwen Code : actualités et guides de coding IA"
-description: "Lisez le blog Qwen Code pour suivre les mises à jour hebdomadaires, pratiques de coding IA, sorties de fonctionnalités et cas d’usage agentic coding."
+title: "Blog Qwen Code"
+description: "Mises à jour produit Qwen Code, pratiques de codage IA et cas d'utilisation réels."
 ---
 
 import { BlogHome } from '@/components/blog-home'

--- a/website/content/ja/blog/index.mdx
+++ b/website/content/ja/blog/index.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Qwen Code ブログ：AI コーディング更新と実践ガイド"
-description: "Qwen Code ブログで毎週の製品更新、AI コーディング実践、機能リリース、実例を読み、agentic coding の最新活用法を確認できます。"
+title: "Qwen Code ブログ"
+description: "Qwen Code 製品アップデート、AI プログラミング実践、実際の活用事例。"
 ---
 
 import { BlogHome } from '@/components/blog-home'

--- a/website/content/pt-BR/blog/index.mdx
+++ b/website/content/pt-BR/blog/index.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Blog Qwen Code: atualizações e guias de programação com IA"
-description: "Leia o blog do Qwen Code com atualizações semanais, práticas de programação com IA, lançamentos de recursos e casos reais de agentic coding."
+title: "Blog Qwen Code"
+description: "Atualizações de produto, práticas de codificação IA e casos de uso reais do Qwen Code."
 ---
 
 import { BlogHome } from '@/components/blog-home'

--- a/website/content/ru/blog/index.mdx
+++ b/website/content/ru/blog/index.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Блог Qwen Code: обновления и гайды по AI-coding"
-description: "Читайте блог Qwen Code: еженедельные обновления, практики AI-coding, релизы функций и реальные сценарии agentic coding для разработчиков."
+title: "Блог Qwen Code"
+description: "Обновления продукта Qwen Code, практики AI-программирования и реальные кейсы."
 ---
 
 import { BlogHome } from '@/components/blog-home'

--- a/website/content/zh/blog/index.mdx
+++ b/website/content/zh/blog/index.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Qwen Code 博客：AI 编程更新与实践指南"
-description: "阅读 Qwen Code 博客，获取每周产品更新、AI 编程实践、功能发布和真实案例，快速了解 agentic coding 的最新用法与上手建议。"
+title: "Qwen Code 博客"
+description: "Qwen Code 产品更新、AI 编程实践与真实使用案例。"
 ---
 
 import { BlogHome } from '@/components/blog-home'


### PR DESCRIPTION
## Summary

Reverts the net changes introduced by #100. This restores the previous `title` and `description` frontmatter on the seven localized blog index pages. Other SEO changes remain unchanged.

## Verification

- Applied the merge revert cleanly against the latest `main`
- `git diff --check`