### PR TITLE
fix(site): 修复目录首页被误判为「未翻译」

### DIFF
--- a/website/app/[lang]/[[...mdxPath]]/page.jsx
+++ b/website/app/[lang]/[[...mdxPath]]/page.jsx
@@ -71,8 +71,10 @@ function getContentFile(lang, mdxPath) {
   const contentRoot = path.join(process.cwd(), "content", lang);
 
   for (const extension of [".mdx", ".md"]) {
-    const filePath = path.join(contentRoot, `${relativePath}${extension}`);
-    if (fs.existsSync(filePath)) return filePath;
+    for (const candidate of [relativePath, path.join(relativePath, "index")]) {
+      const filePath = path.join(contentRoot, `${candidate}${extension}`);
+      if (fs.existsSync(filePath)) return filePath;
+    }
   }
 
   return null;


### PR DESCRIPTION
`getContentFile` 只会去找 `<路径>.mdx` / `<路径>.md` 这种同名文件。博客首页、博客分类页、视频演示页这些存成 `<目录>/index.mdx` 的页面，就被当成了「这个语言没有这篇内容」。

后果是：所有非英文的这类页面顶部都会挂一条「This page has not been translated yet. Showing the English version.」（本页面尚未翻译，正在显示英文版本）的警告，页面内容明明已经是该语言了；同时这些页面还会丢掉多语言互相指向的 hreflang 链接。

现在改成同名文件和目录里的 index 文件都会查找，同名文件优先，所以已有页面解析到的仍然是原来那个文件，行为不变。

- 7 种语言共 39 个页面的误报警告消失，hreflang 链接一并恢复。
- 真的没翻译的页面仍然正常回退到英文、仍然显示该警告（已验证 `ko/blog/advanced`）。
- `npm run test` 通过。
<img width="2502" height="1390" alt="image" src="https://github.com/user-attachments/assets/2c9c1457-cc8a-4d27-81f2-916b5379115c" />
