### PR TITLE
fix(blog): 手机控制教程归入入门分类并补封面

### DIFF
--- a/website/content/en/blog/quickstart/_meta.ts
+++ b/website/content/en/blog/quickstart/_meta.ts
@@ -3,4 +3,5 @@ export default {
   'getting-started': 'Getting Started Guide',
   'thinks-like-a-programmer': 'An Assistant That Thinks Like a Programmer',
   'channels-weixin-launch-announcement': 'Using Qwen Code in WeChat',
+  'feat-qwen-serve-mobile': 'Qwen Code in Your Pocket',
 };

--- a/website/content/en/blog/quickstart/feat-qwen-serve-mobile.mdx
+++ b/website/content/en/blog/quickstart/feat-qwen-serve-mobile.mdx
@@ -4,6 +4,7 @@ date: "2026-08-27"
 description: "Use qwen serve --local-control to open the Qwen Code Web Shell on your phone over a trusted LAN, with a revocable pairing token and QR code."
 author: "pomelo-nwu"
 tags: ["Tutorials", "feature"]
+image: "https://img.alicdn.com/imgextra/i4/O1CN01EhO6cWmSwDB2jBZY_!!6000000001175-2-tps-1344-576.png"
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/content/zh/blog/quickstart/_meta.ts
+++ b/website/content/zh/blog/quickstart/_meta.ts
@@ -3,4 +3,5 @@ export default {
   'getting-started': '快速入门指南',
   'thinks-like-a-programmer': '像程序员一样思考的助手',
   'channels-weixin-launch-announcement': '在微信使用 Qwen Code',
+  'feat-qwen-serve-mobile': '把 Qwen Code 揣进兜里',
 };

--- a/website/content/zh/blog/quickstart/feat-qwen-serve-mobile.mdx
+++ b/website/content/zh/blog/quickstart/feat-qwen-serve-mobile.mdx
@@ -4,6 +4,7 @@ date: "2026-08-27"
 description: "使用 qwen serve --local-control，通过可撤销的配对 token 和二维码，在可信局域网内用手机打开 Qwen Code Web Shell。"
 author: "pomelo-nwu"
 tags: ["Tutorials", "feature"]
+image: "https://img.alicdn.com/imgextra/i4/O1CN01EhO6cWmSwDB2jBZY_!!6000000001175-2-tps-1344-576.png"
 ---
 
 import { BlogPostHeader } from '@/components/blog-post-header'

--- a/website/src/components/blog-feed.tsx
+++ b/website/src/components/blog-feed.tsx
@@ -193,20 +193,24 @@ export function BlogFeed({
   const [filter, setFilter] = useState<FilterId>("all");
   const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
 
+  // 顶部大图已经单独展示那一篇，网格和分类计数按同一口径排除它，
+  // 否则标签写 4、下面只画 3，用户会去找那篇"消失"的文章。
+  const gridPosts = posts.filter((p) => p.route !== heroRoute);
+
   const counts = CATEGORY_IDS.reduce(
     (acc, catId) => {
-      acc[catId] = posts.filter((p) => p.category === catId).length;
+      acc[catId] = gridPosts.filter((p) => p.category === catId).length;
       return acc;
     },
     {} as Record<string, number>
   );
-  const evergreenCount = posts.filter((p) => p.category !== "updates").length;
+  const evergreenCount = gridPosts.filter(
+    (p) => p.category !== "updates"
+  ).length;
 
-  const filtered = posts.filter((p) => {
-    if (p.route === heroRoute) return false;
-    if (filter === "all") return p.category !== "updates";
-    return p.category === filter;
-  });
+  const filtered = gridPosts.filter((p) =>
+    filter === "all" ? p.category !== "updates" : p.category === filter
+  );
   const visible = filtered.slice(0, visibleCount);
   const remaining = filtered.length - visible.length;
 


### PR DESCRIPTION
博客首页两个展示问题一起修。

**1. 手机控制教程归位 + 补封面**

这篇直接放在 `blog` 根目录（全站唯一一篇），分类徽章因此把内部字段名 `root` 原样印到页面上，封面位也因为漏了 `image` 只剩一个 `>_` 占位符。移入 `blog/quickstart/`，补上封面（按入门分类的微距实物风格出图）。

⚠️ 地址会多出 `quickstart` 一段，站点没有重定向，旧地址 404。站内已确认无硬链接，但这篇 8-27 就发布了，站外若分享过会失效。若不接受换地址，替代做法是位置不动、只给 `root` 登记显示名——但那样按「入门」筛选时这篇不会出现。
<img width="2762" height="1088" alt="image" src="https://github.com/user-attachments/assets/f193f9d0-c896-412e-91a7-284a7f29001c" />

**2. 分类计数与网格同口径**

网格会排除顶部大图那篇，分类计数没排除，于是标签写「入门 4」、下面只画 3 张。改成两者取同一份列表，各分类之和也等于「全部」。