### PR TITLE
ci: add throwaway PAT smoke test workflow

### DIFF
--- a/.github/workflows/pat-smoke-test.yml
+++ b/.github/workflows/pat-smoke-test.yml
@@ -1,0 +1,108 @@
+# Throwaway probe for the PAT-based auto-PR path (see #253 / the daily-translate
+# rework). It answers exactly three questions, in ~30s and at zero model spend:
+#
+#   1. Is TRANSLATION_BOT_PAT wired into Actions and does it have the rights?
+#   2. Does a PAT get past the org policy that forbids Actions from creating
+#      PRs with GITHUB_TOKEN? (This is the one real unknown.)
+#   3. Does a PAT-merged PR trigger deploy-docs.yml? (A GITHUB_TOKEN merge does
+#      NOT, which is why the auto-merge variant needs the PAT anyway.)
+#
+# It exists because the real step cannot be rehearsed: `Publish translation
+# review branch` is gated on `github.ref_name == 'main'`, so a dispatch from a
+# test branch skips it, while a dispatch on main burns a full ~3h translation
+# before reaching the five lines under test.
+#
+# DELETE THIS FILE once the answers are in — along with the branch and PR it
+# leaves behind. It is a probe, not infrastructure.
+#
+# Usage: Actions -> "PAT smoke test" -> Run workflow (on main).
+#   Q1+Q2: a PR appears -> the PAT path works.
+#   Q3:    merge that PR, then check whether "Build and Deploy Qwen Code Docs
+#          Website" starts on its own. Set merge_pr below to do it in-run.
+
+name: PAT smoke test
+
+on:
+  workflow_dispatch:
+    inputs:
+      merge_pr:
+        description: "Also merge the PR, to test whether deploy-docs.yml fires"
+        type: boolean
+        default: false
+
+# Deliberately NOT `pull-requests: write`. Granting it would make the result
+# ambiguous — the point is to prove the PAT creates the PR, not GITHUB_TOKEN.
+# `contents: write` is still needed: the branch push below uses the credentials
+# actions/checkout persists (GITHUB_TOKEN), mirroring the real workflow, and the
+# repo default for that token is read-only.
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  smoke:
+    name: Create a throwaway PR with the PAT
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Probe
+        env:
+          GH_TOKEN: ${{ secrets.TRANSLATION_BOT_PAT }}
+          MERGE_PR: ${{ inputs.merge_pr }}
+        run: |
+          set -euo pipefail
+
+          # An unset secret expands to an empty string and every gh call below
+          # would fail as a confusing 401. Say what actually went wrong.
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "::error::secret TRANSLATION_BOT_PAT is empty or not set on this repo"
+            exit 1
+          fi
+
+          # Which identity is the PAT? The PR author will be this user, and so
+          # will the merge commit — that is what makes deploy-docs.yml fire.
+          echo "PAT identity: $(gh api user --jq .login)"
+
+          branch="test/pat-smoke-${GITHUB_RUN_ID}"
+          git config user.name "qwen-docs-bot"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Any non-empty diff will do; keep it to one throwaway file outside
+          # website/ so it cannot reach the built site even if something goes
+          # wrong and this lands on main.
+          echo "PAT smoke test, run ${GITHUB_RUN_ID}" > .pat-smoke
+          git add .pat-smoke
+          git commit -m "chore: PAT smoke test (run ${GITHUB_RUN_ID})"
+          git push origin "HEAD:${branch}"
+
+          # THE test. Under GITHUB_TOKEN this is the call that 403s.
+          url="$(gh pr create --repo "$GITHUB_REPOSITORY" \
+            --base main --head "$branch" \
+            --title "chore: PAT smoke test (run ${GITHUB_RUN_ID})" \
+            --body "Throwaway probe of the PAT auto-PR path. Safe to close and delete.")"
+          echo "created: ${url}"
+          echo "### PAT smoke test: PR created" >> "$GITHUB_STEP_SUMMARY"
+          echo "${url}" >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "${MERGE_PR}" != "true" ]; then
+            echo "Not merging. Close the PR and delete branch ${branch} when done."
+            exit 0
+          fi
+
+          # `--merge`, never `--squash`: a squash commit takes the PR title, and
+          # the real translation commits carry [skip ci], which would silently
+          # suppress the very deploy run this is trying to observe.
+          gh pr merge "$url" --repo "$GITHUB_REPOSITORY" --merge --delete-branch
+          echo "merged. Now check Actions for a 'Build and Deploy Qwen Code Docs Website'"
+          echo "run that started on its own — that is the Q3 answer."
+          echo "Merged; watch for a self-started deploy run." >> "$GITHUB_STEP_SUMMARY"
+
+          # Merging put .pat-smoke on main. Take it straight back off.
+          git fetch origin main
+          git checkout -q -B cleanup origin/main
+          git rm -q .pat-smoke
+          git commit -q -m "chore: remove PAT smoke test artifact [skip ci]"
+          git push origin HEAD:main

--- a/.github/workflows/pat-smoke-test.yml
+++ b/.github/workflows/pat-smoke-test.yml
@@ -42,6 +42,9 @@ permissions:
 jobs:
   smoke:
     name: Create a throwaway PR with the PAT
+    # workflow_dispatch can target any ref, but merging the probe PR writes to
+    # main, so the probe itself must only ever run from main.
+    if: github.ref_name == 'main'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -71,8 +74,10 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
           # Any non-empty diff will do; keep it to one throwaway file outside
-          # website/ so it cannot reach the built site even if something goes
-          # wrong and this lands on main.
+          # website/ so it cannot alter the built site output even if something
+          # goes wrong and this lands on main. (deploy-docs.yml fires on ANY
+          # push to main regardless of which files changed — observing that is
+          # the point of Q3; this file merely keeps the built site untouched.)
           echo "PAT smoke test, run ${GITHUB_RUN_ID}" > .pat-smoke
           git add .pat-smoke
           git commit -m "chore: PAT smoke test (run ${GITHUB_RUN_ID})"


### PR DESCRIPTION
A throwaway probe for the PAT-driven auto-PR path. **Delete it once the answers are in — it is a probe, not infrastructure.**

## Why it is needed

The step we actually want to change in `daily-translate.yml` cannot be rehearsed:

```yaml
if: steps.detect.outputs.changed == 'true' && github.ref_name == 'main'
```

A dispatch from a test branch is blocked by `github.ref_name == 'main'`; a dispatch on `main` first runs ~3h of translation and burns a round of API quota before reaching the lines under test. Neither works, hence a standalone probe that takes ~30s and costs no model spend.

## The three questions it answers

1. Is `TRANSLATION_BOT_PAT` wired into Actions correctly, and does it have the necessary rights?
2. Does a PAT get past the org policy forbidding Actions from creating PRs?
3. Does a PAT-driven merge trigger `deploy-docs.yml`? (`GITHUB_TOKEN` does not, which is precisely why any auto-merge variant needs the PAT.)

The premise behind #2 is already confirmed: the repository-level toggle cannot be flipped — the API returns `409 The organization does not allow GitHub Actions to create or approve pull requests` — so a PAT is the only viable route.

## Design notes

- **Deliberately no `pull-requests: write`.** Granting it would make the result unreadable — the point is to prove the PR is created *by the PAT*, not by a newly privileged `GITHUB_TOKEN`. `contents: write` is required, though: the branch push uses the credentials `actions/checkout` persists (`GITHUB_TOKEN`), mirroring the real workflow, and that token is read-only by default in this repo.
- **`--merge`, not `--squash`.** A squash commit inherits the PR title, and real translation commits carry `[skip ci]`, which would silently suppress the very deploy run this is meant to observe.
- **Explicit error on an empty secret**, which otherwise surfaces as a string of hard-to-attribute 401s.
- The test file `.pat-smoke` lives outside `website/`, so it cannot reach the site build even if something goes wrong. When `merge_pr` is set, the run pushes a follow-up commit removing it from `main` immediately after merging.

## Usage

After merging: Actions → "PAT smoke test" → Run workflow (must be on `main`; `workflow_dispatch` only registers files present on the default branch). First run without `merge_pr`, to see whether the PR is created at all. Second run with it set, watching for a self-started `Build and Deploy` run.

When done, delete this file, any leftover `test/pat-smoke-*` branches, and the test PR.

<details>
<summary>中文</summary>

一次性探针,用来验证 PAT 驱动的自动建 PR 路径。**答案拿到后即删,它不是基础设施。**

**为什么需要**:`daily-translate.yml` 里真正要改的那一步没法演练 —— 从测试分支 dispatch 会被 `github.ref_name == 'main'` 挡掉;从 main dispatch 则要先跑完约 3 小时翻译、烧一遍 API 额度才能走到待测代码。所以单独做一个 30 秒、零模型花费的探针。

**它回答三个问题**:(1) `TRANSLATION_BOT_PAT` 是否正确接入 Actions、权限是否足够;(2) PAT 能否绕开 org 那条禁止 Actions 建 PR 的策略;(3) PAT 发起的合并能否触发 `deploy-docs.yml`(`GITHUB_TOKEN` 不能,这正是自动合并方案必须用 PAT 的原因)。

第 2 点的前提已确认:仓库级开关翻不动,API 返回 `409 The organization does not allow GitHub Actions to create or approve pull requests`,PAT 是唯一可行路径。

**设计细节**:故意不给 `pull-requests: write`,否则结果不可判读 —— 要证的是 PR 由 PAT 建出,而非 `GITHUB_TOKEN` 被放权;`contents: write` 则必须有。用 `--merge` 而非 `--squash`,因为 squash commit 会继承带 `[skip ci]` 的标题,反而把我们想观察的那次 deploy 静默掉。空 secret 显式报错。测试文件放在 `website/` 之外,勾选 `merge_pr` 时合并后立即推 commit 将其从 main 移除。

**用法**:合并后 Actions → "PAT smoke test" → Run workflow(必须在 main 上)。第一次不勾 `merge_pr`,只看 PR 建不建得出来;第二次勾上,观察是否自发出现一次 `Build and Deploy`。用完删掉本文件、残留的 `test/pat-smoke-*` 分支和测试 PR。

</details>

https://claude.ai/code/session_01Sa8YZQrbc74Rdsfbhibkjy
