### PR TITLE
ops: add a check for the nightly translation PR

### DIFF
--- a/scripts/check-nightly-translation.sh
+++ b/scripts/check-nightly-translation.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# Did last night's translation run open its own PR?
+#
+# Since #258 the scheduled `Daily Incremental Translation` workflow opens its
+# own pull request with TRANSLATION_BOT_PAT. This checks that it did, and says
+# what to do when it did not.
+#
+# The author check is the point. "A PR exists" is not evidence the automation
+# worked — before #258 a human opened it by hand, which looks identical from
+# the outside. Only a PR authored by the bot proves the workflow did it.
+#
+# Usage: scripts/check-nightly-translation.sh
+# Requires: gh, authenticated with read access to the repo.
+
+set -uo pipefail
+
+R="${REPO:-QwenLM/qwen-code-docs}"
+BOT="${BOT_LOGIN:-qwen-code-review-bot}"
+
+read -r id st cc < <(gh run list --repo "$R" --workflow "Daily Incremental Translation" \
+  --limit 1 --json databaseId,status,conclusion \
+  --jq '"\(.[0].databaseId) \(.[0].status) \(.[0].conclusion // "-")"')
+branch="automation/daily-translation-$id"
+echo "run : $id  $st/$cc   https://github.com/$R/actions/runs/$id"
+
+read -r num state author url < <(gh pr list --repo "$R" --state all --head "$branch" \
+  --limit 1 --json number,state,author,url \
+  --jq '.[0] | "\(.number) \(.state) \(.author.login) \(.url)"' 2>/dev/null)
+
+if [ -n "${num:-}" ] && [ "$author" = "$BOT" ]; then
+  echo "PR  : #$num $state by $author  <-- OK, the run opened it itself"
+  echo "      $url"
+elif [ -n "${num:-}" ]; then
+  echo "PR  : #$num $state by $author  <-- opened by a human, not the workflow"
+elif gh api "repos/$R/branches/$branch" -q .name >/dev/null 2>&1; then
+  # The branch is pushed before the PR is opened, so translation work is never
+  # lost this way — but the run failed and needs a look.
+  echo "PR  : NONE, but branch $branch exists  <-- gh pr create failed; read the log:"
+  echo "      gh run view $id --repo $R --log | grep -i -A5 'Publish translation PR'"
+else
+  echo "PR  : none, no branch  <-- quiet night, or the run paused on a pending PR"
+fi
+
+# A run skips its model work entirely while any translation PR is unmerged, so
+# an unreviewed PR costs a night of translation. Between 09-02 and 09-06, five
+# consecutive nights were skipped this way.
+open=$(gh pr list --repo "$R" --state open --limit 30 --json headRefName \
+  --jq '[.[] | select(.headRefName | startswith("automation/"))] | length')
+echo "open: $open translation PR(s) — runs stay paused while any is open"
+
+# The pipeline only advances this once a batch merges, so it doubles as a
+# "how long has the gate been shut" reading. The workflow itself warns past 3d.
+ts=$(gh api "repos/$R/contents/website/last-sync.json" --jq .content 2>/dev/null \
+  | base64 -d | grep -o '"timestamp": *"[^"]*"' | head -1 | cut -d'"' -f4)
+if [ -n "$ts" ]; then
+  age=$(( ( $(date -u +%s) - $(date -u -d "$ts" +%s) ) / 86400 ))
+  echo "base: last-sync ${ts%T*} (${age}d old)$( [ "$age" -gt 3 ] && echo '  <-- stale, backlog growing' )"
+fi
+
+exit 0


### PR DESCRIPTION
A one-command check for whether last night's scheduled run opened its own PR, as #258 made it do.

## Why it checks the author

"A PR exists" is not evidence the automation worked. Before #258 a human opened it by hand, and from the outside that looks identical. So the script asserts the PR is authored by `qwen-code-review-bot`, and says so explicitly when a human opened it instead.

Sample output, run against the current state:

```
run : 34167611128  completed/success   https://github.com/QwenLM/qwen-code-docs/actions/runs/34167611128
PR  : #254 OPEN by yiliang114  <-- opened by a human, not the workflow
open: 1 translation PR(s) — runs stay paused while any is open
base: last-sync 2026-09-02 (6d old)  <-- stale, backlog growing
```

It correctly refuses to credit the workflow for #254, which I opened manually.

## The four outcomes

| Output | Meaning |
| --- | --- |
| PR by the bot | working |
| PR by a person | the workflow did not do it |
| No PR but the branch exists | `gh pr create` failed; prints the command to read the log |
| Neither | a quiet night, or the run paused on a pending PR |

Translation work is never lost in the third case: the branch is pushed before the PR is opened.

## The last two lines are the real story

A run skips its model work entirely while any translation PR is unmerged, so an unreviewed PR costs a night of translation. That is not hypothetical — the run durations tell it plainly:

| Night | Duration |
| --- | --- |
| 09-01 | 209 min |
| 09-02 … 09-06 | 0 min each |
| 09-07 | 186 min |

The 09-01 run pushed its branch, no PR was opened for it until 09-07, and **five consecutive nights did nothing at all**. #258 removes that specific failure — nobody has to remember to open the PR — but the gate now moves to reviewing it. These two lines make the cost visible before another five nights go by.

<details>
<summary>中文</summary>

一条命令检查昨晚的定时运行有没有自己建 PR(#258 让它这么做)。

**为什么检查作者**:"存在 PR"不等于自动化生效了 —— #258 之前是人手建的,从外面看长得一模一样。所以脚本断言 PR 作者是 `qwen-code-review-bot`,若是人建的会明确指出。上面的示例输出就正确地拒绝把 #254 算作工作流的功劳(那是我手建的)。

**四种结果**:机器人建的(正常)/ 人建的(工作流没干活)/ 有分支没 PR(`gh pr create` 挂了,并打印读日志的命令)/ 都没有(安静的一天,或被 pending PR 暂停)。第三种情况不会丢翻译成果:分支在建 PR 之前就已推送。

**最后两行才是重点**:只要有任何一个翻译 PR 未合并,运行就会完全跳过模型工作 —— 也就是说一个没人 review 的 PR 等于损失一整晚翻译。这不是假设:09-01 跑了 209 分钟并推了分支,但直到 09-07 才有人为它建 PR,**中间 09-02 至 09-06 连续五晚颗粒无收**。#258 消除了"没人记得建 PR"这个环节,但闸口随之转移到了 review 上。这两行让代价在下一个五晚流逝之前就可见。

</details>

https://claude.ai/code/session_01Sa8YZQrbc74Rdsfbhibkjy
