### PR TITLE
ci: keep the quarantine report instead of discarding it

### DIFF
--- a/.github/workflows/daily-translate.yml
+++ b/.github/workflows/daily-translate.yml
@@ -313,9 +313,18 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: translation-metrics
+          # quarantine-unrepairable.json carries the per-file reasons for
+          # every file quarantine could not repair. It used to be thrown away
+          # with the runner, leaving check-run annotations as the only record:
+          # one line per file, no reasons, reachable only run by run. #260 had
+          # to be reconstructed that way, from two runs, by hand.
+          #
+          # Note these are paths, not YAML: a `#` inside the block scalar below
+          # is a literal path pattern, not a comment.
           path: |
             website/translation-metrics.json
             website/orchestrator-manifest-*.metrics.json
+            website/quarantine-unrepairable.json
           retention-days: 90
           if-no-files-found: ignore
 

--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ jspm_packages/
 website/orchestrator-manifest-*.json
 website/orchestrator-agent-*.log
 website/translation-metrics.json
+website/quarantine-unrepairable.json
 website/tsconfig.tsbuildinfo
 
 # other


### PR DESCRIPTION
`orchestrator.mjs quarantine` already writes `website/quarantine-unrepairable.json`, holding the per-file reasons for every file it could not repair — and then the runner is torn down and takes it along. Adds it to the metrics artifact, which is uploaded with 90-day retention.

## Why it matters

What survives today is the check-run annotations: one line per file, **no reasons**, and reachable only run by run. Reconstructing #260 meant scraping two separate runs by hand and re-deriving the failure reasons locally.

The report has exactly what the annotations lack:

```json
[
  {
    "entry": "de/developers/qwen-serve-protocol.md",
    "headBad": ["code fence mismatch (en=244 de=226)"],
    "newBad":  ["code fence mismatch (en=244 de=226)"]
  }
]
```

`headBad` equal to `newBad` *is* the #260 deadlock, stated in one line: the file was restored to a state that fails for the same reason it just failed for. With this uploaded, repeat offenders become countable across the retention window instead of archaeological.

## Verification

Ran `quarantine` against the 09-07 batch branch (`automation/daily-translation-34167611128`) with a synthetic failed-list of two of the stuck files:

```
[orch] quarantine: 2 restored from HEAD, 0 kept over a corrupt HEAD, 0 removed, 2 unrepairable
[orch] quarantine: wrote .../website/quarantine-unrepairable.json
```

The path matches what the upload step now collects — the report goes to `path.dirname(OPTS.baseline)`, and `baseline` defaults to `website/last-sync.json`. The output above is where the JSON excerpt in this description comes from, and it independently confirms the #260 diagnosis.

The step keeps `if-no-files-found: ignore`, so a quiet night with nothing quarantined still uploads cleanly.

## Two details

- The comment sits **above** `path:`, not inside it. The block scalar is a list of path patterns, not YAML — a `#` line in there would be taken as a literal pattern, not a comment. Noted inline so the next person does not move it down.
- Also gitignored. It is untracked output the publish step never stages (`git add` names only `website/content` and `website/last-sync.json`), but it should not linger in `git status` after a local quarantine run when every other orchestrator artifact is already ignored.

<details>
<summary>中文</summary>

`orchestrator.mjs quarantine` 本就会写出 `website/quarantine-unrepairable.json`,内含每个无法修复文件的逐条原因 —— 然后 runner 销毁,把它一起带走。本 PR 把它加入 metrics artifact(保留 90 天)。

**为什么重要**:目前留存下来的只有 check-run annotation:每文件一行、**没有原因**,而且只能逐次运行去翻。重建 #260 时我得手工刮取两次运行的记录,再在本地重新推导失败原因。而这份报告恰好有 annotation 缺的东西:`headBad` 与 `newBad` 相同,这一行本身**就是** #260 的死锁 —— 文件被恢复到了一个因同样原因必然再次失败的状态。上传之后,重复出现的问题文件就从"考古"变成"可计数"。

**验证**:在 09-07 的批次分支上,用两个卡住文件构造 failed-list 跑了一次 `quarantine`,报告如期产出,路径与上传步骤新采集的一致(报告写入 `path.dirname(OPTS.baseline)`,而 `baseline` 默认为 `website/last-sync.json`)。本 PR 描述中的 JSON 片段即来自该次运行,它同时独立印证了 #260 的诊断。该步骤保留 `if-no-files-found: ignore`,所以无隔离发生的安静夜晚仍能正常上传。

**两个细节**:注释放在 `path:` **上方**而非其中 —— 该 block scalar 是路径模式列表而非 YAML,`#` 开头的行会被当作字面路径模式而不是注释,已就地注明以免后人挪动。另外加了 gitignore:它是发布步骤从不 stage 的未跟踪产物,但本地跑完 quarantine 后不该留在 `git status` 里,其余 orchestrator 产物早已被忽略。

</details>

Ref #260.

https://claude.ai/code/session_01Sa8YZQrbc74Rdsfbhibkjy
