### PR TITLE
ops: preserve the agent logs and name the dispatched files

### DIFF
--- a/.github/workflows/daily-translate.yml
+++ b/.github/workflows/daily-translate.yml
@@ -319,12 +319,20 @@ jobs:
           # one line per file, no reasons, reachable only run by run. #260 had
           # to be reconstructed that way, from two runs, by hand.
           #
+          # orchestrator-agent-*.log holds what each agent session actually
+          # returned. Only its stderr reaches the step log, so a rejected
+          # structured output shows up there as a bare parse error with no way
+          # to see the response that caused it. One log per attempt, and a
+          # failed attempt keeps its own (`-retryN`), so a deterministic
+          # failure is visible as the same rejection twice.
+          #
           # Note these are paths, not YAML: a `#` inside the block scalar below
           # is a literal path pattern, not a comment.
           path: |
             website/translation-metrics.json
             website/orchestrator-manifest-*.metrics.json
             website/quarantine-unrepairable.json
+            website/orchestrator-agent-*.log
           retention-days: 90
           if-no-files-found: ignore
 

--- a/translator/orchestrator/orchestrator.mjs
+++ b/translator/orchestrator/orchestrator.mjs
@@ -732,9 +732,14 @@ async function cmdTranslate(lang) {
   for (const chunk of chunks) {
     part++;
     const suffix = chunks.length > 1 ? `-part${part}` : "";
+    // Name the files, not just the count. A structured-output rejection that
+    // fails before per-document context — a truncated JSON response, say —
+    // reports only the parse error, so the step log alone could not say which
+    // document was lost. That gap cost a full investigation pass on #260.
     console.log(
       `[orch] ${lang}: dispatching agent for ${chunk.length} file(s)` +
-        (chunks.length > 1 ? ` (part ${part}/${chunks.length})...` : "...")
+        (chunks.length > 1 ? ` (part ${part}/${chunks.length})` : "") +
+        `: ${chunk.map((c) => relInContent(c.file)).join(", ")}...`
     );
     let status;
     let log;


### PR DESCRIPTION
Investigating #260 ran out of evidence twice. This closes both gaps. It is step 1 of three; steps 2 and 3 are deliberately not here, because tonight's run should decide between them.

## What was missing

The agent session logs (`orchestrator-agent-*.log`) hold what each session actually returned. They are gitignored and in no artifact, so the runner takes them. Only **stderr** reaches the step log — and the interesting part of a rejection is in the response, which goes to stdout.

The result, from run [34286265763](https://github.com/QwenLM/qwen-code-docs/actions/runs/34286265763):

```
[orch] rejected structured output: Unterminated string in JSON at position 143146
```

Nineteen of those. No way to see the truncated response, and **no way to tell which document it was**, because the dispatch line reported a count and no names:

```
[orch] de: dispatching agent for 1 file(s) (part 3/40)...
```

## Changes

**Upload the logs** with the existing metrics artifact.

**Name the chunk's files at dispatch:**

```
[orch] de: dispatching agent for 1 file(s) (part 3/40): users/features/goals.md...
```

The count-and-no-names form predates `TRANSLATE_CHUNK = 1`, when a line naming fifteen files would have been noise. With one file per session it is the single most useful thing that line can carry, and it makes the step log alone answer "which document" without downloading anything.

`cmdReportBatch()` parses this line with `/dispatching agent for (\d+) file/`; the prefix is unchanged and the regex still matches — verified against the new string.

## Why every log, not just failures

`agentLogStats()` derives halt and retry-recovery counts by scanning `-retryN` logs for `agent exit=0`. Pruning successful logs would zero out `retriesRecovered` — a metric this change exists to explain. Keeping all of them costs a text artifact that compresses well; keeping the wrong subset costs a number nobody can trust.

## What it will show tonight

The two failure modes found in #260, with enough detail to act on:

| Mode | Count in run 34286265763 | What the log adds |
| --- | --- | --- |
| `replacement N does not match exactly once` | 54 | The search string the model produced, so 0-matches and >1-matches can finally be told apart |
| Truncated JSON response | 19 | The response, and which document it belonged to |

Both are all-or-nothing: one bad replacement discards the whole document's translation, which is why the file then reads as `target not touched this session`.

<details>
<summary>中文</summary>

排查 #260 两次撞到证据不足,本 PR 把两个缺口都补上。这是三步中的第 1 步;第 2、3 步刻意不放进来,因为今晚的运行结果应当用来决定优先做哪一个。

**缺什么**:agent 会话日志(`orchestrator-agent-*.log`)记录了每个会话实际返回的内容,但它被 gitignore、不在任何 artifact 里,随 runner 销毁。只有 **stderr** 会进入步骤日志,而一次拒绝中真正有价值的部分在响应里,走的是 stdout。结果就是运行 34286265763 里出现 19 条 `Unterminated string in JSON at position 143146` —— 既看不到被截断的响应,**也无法判断是哪个文档**,因为派发行只报数量不报文件名。

**改动**:把日志并入现有 metrics artifact;派发行补上文件名。"只报数量"的写法早于 `TRANSLATE_CHUNK = 1` —— 当年一行列出 15 个文件确实是噪音,而现在每个会话一个文件,文件名是这行能携带的最有用的信息,并且让步骤日志本身就能回答"是哪个文档",无需下载任何东西。`cmdReportBatch()` 用 `/dispatching agent for (\d+) file/` 解析该行,前缀未变、正则仍匹配,已针对新字符串验证。

**为什么全量上传而非只留失败**:`agentLogStats()` 通过扫描 `-retryN` 日志中的 `agent exit=0` 来统计 halt 与重试恢复数。裁掉成功日志会把 `retriesRecovered` 直接清零 —— 而这正是本次改动想要解释的指标之一。全部保留的代价是一份压缩率很高的文本产物;保留错误的子集,代价是一个没人敢信的数字。

**今晚能看到什么**:#260 中发现的两类失败(补丁搜索串不唯一匹配 54 次、响应 JSON 截断 19 次)将首次带有可据以行动的细节 —— 前者能区分"零匹配"与"多匹配",后者能看到响应本身及其所属文档。两者都是全或无:任何一条补丁出问题,整篇文档的翻译全部丢弃,该文件随后就表现为 `target not touched this session`。

</details>

Ref #260.

https://claude.ai/code/session_01Sa8YZQrbc74Rdsfbhibkjy
