### PR TITLE
ci: run the website tests, and make the glob actually recurse

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,59 @@
+# The website's tests existed before this workflow but nothing ran them, so a
+# regression they cover would still have reached main (#158 added the first
+# src/ test and hit exactly that).
+#
+# Scoped to code paths on purpose. The nightly translation PR touches hundreds
+# of files under website/content, and none of them can affect a unit test — a
+# `website/**` filter would run this on every one of those for nothing.
+name: Tests
+
+on:
+  pull_request:
+    paths:
+      - "website/src/**"
+      - "website/scripts/**"
+      - "website/package.json"
+      - "website/package-lock.json"
+      - ".github/workflows/tests.yml"
+  push:
+    branches: [main]
+    paths:
+      - "website/src/**"
+      - "website/scripts/**"
+      - "website/package.json"
+      - "website/package-lock.json"
+      - ".github/workflows/tests.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  website:
+    name: Website unit tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: website/package-lock.json
+
+      # `npm ci`, not `npm install`: tsx is a devDependency the test script
+      # needs on PATH, and a partial install is exactly how `npm test` ends up
+      # reporting `sh: 1: tsx: not found`.
+      - name: Install dependencies
+        working-directory: ./website
+        run: npm ci --no-audit --no-fund
+
+      - name: Run tests
+        working-directory: ./website
+        run: npm test

--- a/website/package.json
+++ b/website/package.json
@@ -8,7 +8,7 @@
     "generate-pages": "node scripts/generate-page-registry.js",
     "generate-blog-dates": "node scripts/generate-blog-dates.js",
     "generate": "npm run generate-showcase && npm run generate-pages && npm run generate-blog-dates",
-    "test": "node --test scripts/*.test.js && tsx --test src/**/*.test.ts",
+    "test": "node --test scripts/*.test.js && tsx --test \"src/**/*.test.ts\"",
     "dev": "npm run generate && npm run clean && next dev",
     "build": "npm run generate && node scripts/clean-next.mjs && next build",
     "postbuild": "node scripts/set-html-lang.js && pagefind --site out --output-path out/_pagefind --exclude-selectors 'noscript,script,style,pre,code,.nextra-code-block,.nextra-toc,.nextra-sidebar,.nextra-breadcrumb,.nextra-banner'",

--- a/website/src/components/custom-navbar.tsx
+++ b/website/src/components/custom-navbar.tsx
@@ -8,7 +8,6 @@ import { GitHubIcon, DiscordIcon } from "nextra/icons";
 import { Button } from "nextra/components";
 import { FileText, Star, BookOpen, Newspaper } from "lucide-react";
 import { ThemeToggle } from "./theme-toggle";
-import { get } from "http";
 import { getBasePath } from "@/lib/blog-utils";
 import { getLocaleFromPathname } from "@/lib/locale-path";
 


### PR DESCRIPTION
Follow-up to #158. Both loose ends there were ours, not the contributor's, so they were kept out of that PR rather than asked of someone who had already waited eight weeks.

## Nothing ran `npm test`

No workflow invoked it. The tests #158 added — the first under `website/src` — protected nothing. This adds a `Tests` workflow on `pull_request` and on `main`.

Scoped to code paths on purpose: the nightly translation PR touches hundreds of files under `website/content`, none of which can affect a unit test. A `website/**` filter would run this for nothing on every one of those.

## The glob did not recurse

```
"test": "node --test scripts/*.test.js && tsx --test src/**/*.test.ts"
```

npm runs scripts through `sh`, which has no globstar, so `src/**/*.test.ts` behaved as `src/*/*.test.ts`. It matched the single test that exists today and would have silently skipped any test placed at another depth — the failure mode where the pattern looks correct and the tests simply never run.

Quoting it hands the glob to node's test runner, which does recurse. Verified both ways with a throwaway probe at `src/lib/deep/probe.test.ts`:

| Form | Tests found |
| --- | --- |
| `--test src/**/*.test.ts` | 4 (probe skipped) |
| `--test "src/**/*.test.ts"` | 5 (probe found) |

For the record, `--test src` — pointing the runner at the directory — does **not** work: node reports `not ok 1 - src`. The quoted glob is the form that behaves.

## One unrelated removal

`import { get } from "http"` in `custom-navbar.tsx`: an unused node builtin pulled into a `"use client"` component. It predates #158 and has nothing to do with it, but it sits two lines from the code #158 changed, and leaving it there while touching the file twice in one day seemed worse than removing it. `tsc --noEmit` passes.

## Checks

- `npm ci && npm test` — 1 script test, 4 src tests, all passing.
- `npm test` fails as `sh: 1: tsx: not found` when `node_modules` is stale, which is why the workflow uses `npm ci` rather than `npm install`. That is worth knowing before someone reads a red run as a broken test.

<details>
<summary>中文</summary>

#158 的后续。那里遗留的两项都是我们自己的欠账,而非贡献者的问题,所以没有放进那个 PR、也没有再去要求一个已经等了八周的人。

**没有任何 workflow 调用 `npm test`**,所以 #158 添加的测试(`website/src` 下的第一个)没有保护任何东西。本 PR 新增 `Tests` workflow,在 `pull_request` 与 `main` 上运行。路径刻意收窄到代码目录:每晚的翻译 PR 会改动 `website/content` 下数百个文件,而它们不可能影响单元测试 —— 用 `website/**` 过滤会让这个 workflow 在每一个这样的 PR 上白跑一遍。

**glob 不会递归**:npm 通过 `sh` 执行脚本,而 sh 没有 globstar,`src/**/*.test.ts` 实际等价于 `src/*/*.test.ts`。它匹配到了今天仅有的那个测试,但放在其他层级的测试会被静默跳过 —— 属于"模式看起来没错、测试其实根本没跑"的那类失败。加上引号后由 node 的 test runner 自己做 glob,它确实递归。已用 `src/lib/deep/probe.test.ts` 双向验证:不加引号找到 4 个测试(跳过探针),加引号找到 5 个。附带记录:把 runner 指向目录(`--test src`)**行不通**,node 会报 `not ok 1 - src`,加引号的 glob 才是可用形式。

**一处无关的清理**:`custom-navbar.tsx` 里的 `import { get } from "http"` —— 一个未被使用的 node 内置模块被引入 `"use client"` 组件。它早于 #158、与之无关,但就在 #158 改动行的两行之外,一天之内两次碰这个文件却留着它,似乎比顺手删掉更糟。`tsc --noEmit` 通过。

**验证**:`npm ci && npm test` —— 1 个 scripts 测试 + 4 个 src 测试全部通过。另外,当 `node_modules` 陈旧时 `npm test` 会以 `sh: 1: tsx: not found` 失败,这正是 workflow 使用 `npm ci` 而非 `npm install` 的原因 —— 值得记下来,免得有人把红色的运行误读成测试坏了。

</details>

Ref #158.

https://claude.ai/code/session_01Sa8YZQrbc74Rdsfbhibkjy
