### PR TITLE
ci: move the node20 actions onto the node24 runtime

### DIFF
--- a/.github/workflows/daily-translate.yml
+++ b/.github/workflows/daily-translate.yml
@@ -310,7 +310,7 @@ jobs:
       - name: Upload translation metrics
         if: always()
         continue-on-error: true
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: translation-metrics
           # quarantine-unrepairable.json carries the per-file reasons for
@@ -345,7 +345,7 @@ jobs:
       # pushed a review branch, so there is nothing to preserve locally.
       - name: Upload translations that cannot be committed
         if: always() && steps.detect.outputs.changed == 'true' && (github.ref_name != 'main' || failure())
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: translation-output
           # translation-changelog.json is deliberately not listed: the

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -43,7 +43,7 @@ jobs:
       # Persistent webpack cache (see scripts/clean-next.mjs): warm cache
       # cuts the compile phase from ~4-5min to ~1min.
       - name: Cache Next.js build cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: website/.next/cache
           key: next-${{ runner.os }}-${{ hashFiles('website/package-lock.json') }}-${{ github.sha }}


### PR DESCRIPTION
Every nightly run carries this annotation:

```
Node.js 20 is deprecated. The following actions target Node.js 20 but are
being forced to run on Node.js 24: actions/upload-artifact@v4
```

The runner already forces the newer runtime, so this is noise rather than breakage — but it is noise on every run, and it sits in the same annotation list as the quarantine warnings that actually matter. Last night that list was 20 quarantine warnings plus this.

## Changes

| Action | From | To | Why |
| --- | --- | --- | --- |
| `actions/upload-artifact` | v4 | **v7** | v4 is `node20`; v7 is `node24` |
| `actions/cache` | v4 | **v5** | also `node20`, same class — it just annotates in `deploy-docs.yml` rather than the nightly |

v5 was the obvious target, but v4 → v5 is not the current jump: `upload-artifact` is on **v7.0.1** as of 2026-04. v5 and v6 were both runtime-only releases on the way to node24.

## Compatibility, checked rather than assumed

Read `action.yml` at the `v7` tag against the inputs actually used here:

- `name`, `path`, `retention-days`, `if-no-files-found` — all present, unchanged.
- v7 adds an `archive` input for uploading a single file unzipped. It **defaults to `true`**, so the multi-line path globs in `daily-translate.yml` keep zipping exactly as before. Setting it to `false` would have been the breaking case, and nothing here sets it.
- v6 is where the runtime actually flipped to `node24` by default; v7 additionally moves the package to ESM, which is internal to the action.

`cache` v5 changes nothing but the runtime.

Both majors require an Actions Runner of at least `2.327.1`. That constraint only binds self-hosted runners; every job in this repo is on `ubuntu-latest`.

## Verification

The next nightly run is the check: the deprecation annotation should be gone, and the quarantine warnings should be the only ones left. `peaceiris/actions-gh-pages@v4` is third-party and stays as it is.

<details>
<summary>中文</summary>

每次 nightly 运行都会带上 `Node.js 20 is deprecated ... actions/upload-artifact@v4` 这条注解。runner 已经强制用新运行时,所以这是噪音而非故障 —— 但它每次运行都出现,而且和真正重要的 quarantine 警告挤在同一份注解列表里(昨晚是 20 条 quarantine 警告加上它)。

**改动**:`upload-artifact` v4 → **v7**(v4 是 `node20`,v7 是 `node24`);`actions/cache` v4 → **v5**(同样是 node20,只是它出现在 `deploy-docs.yml` 而非 nightly)。原本预期是升到 v5,但那不是当前的跳转目标:`upload-artifact` 截至 2026-04 已到 **v7.0.1**,v5 与 v6 都只是通往 node24 途中的运行时版本。

**兼容性是查过的,不是假设的**:对照 `v7` tag 上的 `action.yml` 与本仓库实际使用的输入 —— `name`、`path`、`retention-days`、`if-no-files-found` 全部存在且未变;v7 新增的 `archive` 输入(单文件不打包上传)**默认为 `true`**,所以 `daily-translate.yml` 里的多行 path 通配仍照旧打包,只有显式设为 `false` 才会构成破坏性变更,而这里没有设置。v6 才是运行时真正默认切到 node24 的版本,v7 另外把包改为 ESM,属于 action 内部实现。`cache` v5 除运行时外别无变化。

两个大版本都要求 Actions Runner 不低于 `2.327.1`,该约束只对 self-hosted runner 有意义,本仓库所有 job 都跑在 `ubuntu-latest` 上。

**验证**:下一次 nightly 就是检验 —— 弃用注解应当消失,只剩 quarantine 警告。`peaceiris/actions-gh-pages@v4` 是第三方 action,保持原样。

</details>

https://claude.ai/code/session_01Sa8YZQrbc74Rdsfbhibkjy
