### PR TITLE
fix(orchestrator): repair the code-span artifact before rejecting a patch

### DIFF
--- a/translator/orchestrator/orchestrator.mjs
+++ b/translator/orchestrator/orchestrator.mjs
@@ -477,6 +477,46 @@ const TRANSLATE_CHUNK = 1;
 // Retry once; repeated failures stay in the next run's backlog.
 const TRANSLATE_ATTEMPTS = 2;
 
+/**
+ * Trim the inside of inline code spans.
+ *
+ * The translation agent reliably emits `` ` @qwen-code/webui` `` where the
+ * document holds `` `@qwen-code/webui` `` — a spurious space just inside the
+ * span. In run 34412117469 that single artifact accounted for 20 of 54
+ * unmatchable `old` anchors, each one discarding a whole document's
+ * translation. Nothing semantic distinguishes the two, so the anchor is
+ * repaired rather than the model re-prompted (the prompt has told it to copy
+ * verbatim since the beginning; it still does this).
+ *
+ * Only closed spans on a single line are touched, and fenced blocks are left
+ * alone, so `foo` bar keeps its space: that one belongs to the prose between
+ * spans, not to a span.
+ */
+/** Index of `needle` in `hay` when it occurs exactly once, else -1. */
+function matchExactlyOnce(hay, needle) {
+  const at = hay.indexOf(needle);
+  if (at < 0) return -1;
+  return hay.indexOf(needle, at + needle.length) >= 0 ? -1 : at;
+}
+
+function trimCodeSpans(text) {
+  let fenced = false;
+  return text
+    .split("\n")
+    .map((line) => {
+      if (/^\s*(```|~~~)/.test(line)) {
+        fenced = !fenced;
+        return line;
+      }
+      if (fenced) return line;
+      const parts = line.split("`");
+      for (let i = 1; i < parts.length - 1; i += 2)
+        if (parts[i].trim()) parts[i] = parts[i].trim();
+      return parts.join("`");
+    })
+    .join("\n");
+}
+
 function translationSchema(documents) {
   return {
     type: "object",
@@ -597,18 +637,29 @@ function applyTranslationPatches(lang, documents, result) {
           typeof replacement.new !== "string"
         )
           throw new Error(`${rel}: replacement ${i + 1} is invalid`);
-        const at = next.indexOf(replacement.old);
-        if (
-          at < 0 ||
-          next.indexOf(replacement.old, at + replacement.old.length) >= 0
-        )
+        let { old, new: text } = replacement;
+        let at = matchExactlyOnce(next, old);
+        if (at < 0) {
+          // Second attempt with the code-span artifact repaired. Strictly a
+          // fallback: an anchor that already matched never reaches here, so
+          // this cannot change how an accepted patch applies. `new` is
+          // repaired too — it carries the same artifact, and writing it
+          // through would put the malformed span into the published page.
+          const repaired = trimCodeSpans(old);
+          if (repaired !== old) {
+            const retry = matchExactlyOnce(next, repaired);
+            if (retry >= 0) {
+              old = repaired;
+              text = trimCodeSpans(text);
+              at = retry;
+            }
+          }
+        }
+        if (at < 0)
           throw new Error(
             `${rel}: replacement ${i + 1} does not match exactly once`
           );
-        next =
-          next.slice(0, at) +
-          replacement.new +
-          next.slice(at + replacement.old.length);
+        next = next.slice(0, at) + text + next.slice(at + old.length);
       }
     }
     writes.push({ dest, content: next });

--- a/translator/orchestrator/orchestrator.mjs
+++ b/translator/orchestrator/orchestrator.mjs
@@ -509,6 +509,12 @@ function trimCodeSpans(text) {
         return line;
       }
       if (fenced) return line;
+      // A run of two or more backticks is a different construct (a span that
+      // itself contains a backtick), and splitting on single backticks
+      // mis-pairs its delimiters: "Use `` ` x ` `` carefully" would come back
+      // as "Use `` `x` `` carefully". The artifact this repairs only ever
+      // appears in single-backtick spans, so skip the line rather than guess.
+      if (line.includes("``")) return line;
       const parts = line.split("`");
       for (let i = 1; i < parts.length - 1; i += 2)
         if (parts[i].trim()) parts[i] = parts[i].trim();


### PR DESCRIPTION
The agent reliably emits one spurious space just inside an inline code span:

```
model's `old`:  ` @qwen-code/webui`
the document:   `@qwen-code/webui`
```

The anchor then matches nothing. Patches are all-or-nothing, so a single bad anchor discards the entire document's translation, and the file comes back the next night reading as `target not touched this session` — the symptom #260 opens with.

## How much this is worth

Run [34412117469](https://github.com/QwenLM/qwen-code-docs/actions/runs/34412117469) was the first with the agent logs preserved (#264), so the anchors could finally be read. Of its 56 rejected patch sets:

| Cause of the unmatchable anchor | Count |
| --- | --- |
| **Code-span artifact — this PR** | **17** |
| Anchor exists nowhere: not in the target, not in the English source | 37 |
| Anchor occurs more than once | 1 |
| Matches today (the file changed since the run) | 1 |

Zero-match dominates at 54 of 56, and it splits into a mechanical part and a semantic one. This fixes the mechanical part.

Every figure here is produced by the functions as committed. An earlier revision of this description said 20, taken from a broader diagnostic normalizer used while characterising the failures; it was not re-derived against the shipped code. Counting patch sets whose `old` merely *contains* a backtick-space anywhere gives 51 of 56, but that overstates the fix — an anchor can carry the artifact somewhere harmless and still fail for an unrelated reason.

## Verification: replayed against that run

Both numbers come from replaying the run's real agent output against the same inputs, using the two functions as committed here rather than a reimplementation.

**Recovers 15 documents.** Of the 56 rejected patch sets, 1 applies under today's logic; 16 apply with the fallback:

```
de/developers/examples/daemon-client-quickstart.md   fr/developers/daemon/03-acp-bridge.md
fr/developers/examples/daemon-client-quickstart.md   ja/developers/daemon/03-acp-bridge.md
ja/developers/examples/daemon-client-quickstart.md   ko/developers/daemon/03-acp-bridge.md
ko/developers/examples/daemon-client-quickstart.md   pt-BR/developers/daemon/03-acp-bridge.md
ru/developers/examples/daemon-client-quickstart.md
```

**Changes nothing that already worked.** Replaying the 153 patch sets that succeeded in that run gives byte-identical output with and without the fallback. That is structural, not luck: the fallback runs only where `indexOf` already returned -1 and the patch set was about to be thrown away.

## Why repair the anchor instead of re-prompting

`prompts/translate.md` line 8 has said this since the beginning:

> Each `old` value must be copied verbatim from the original current target, occur exactly once there, and include enough unchanged context to be unique.

The 20 failures happened under that instruction. The prompt is not the gap.

## Details worth a second look

- **`new` is repaired too.** It carries the same artifact, and writing it through would put `` ` @qwen-code/web-shell` `` into a published page.
- **Lines carrying a run of two or more backticks are skipped entirely.** Splitting on single backticks mis-pairs the delimiters of a span that itself contains one: `` Use `` ` x ` `` carefully `` would come back as `` Use `` `x` `` carefully ``. Found in review; the corpus has no such spans, but the input here is model output, not the corpus.
- **Only closed, single-line spans, and never inside a fence.** `` `foo` bar `` keeps its space — that one belongs to the prose *between* two spans, which is exactly the case a naive `` /`\s+/ `` regex would corrupt. Verified against the current content: inner-whitespace spans are 0.04–0.10% of all spans per locale, and `en` has 16 of its own, so this is not a pattern being written into the docs at scale.
- **No unit test.** `applyTranslationPatches` is only reachable through a live model call, and the existing orchestrator tests drive the CLI. Rather than restructure the module for a seam, the replay above is the evidence — it runs the committed functions against 209 real patch sets.

## Not in scope

The other 34, where the anchor exists nowhere: the model paraphrases the target instead of quoting it, at a median anchor length of 199 characters. That needs a different answer — probably degrading to a full-file rewrite — and it carries a judgement call this PR deliberately does not make: a model that cannot copy accurately may not be safe to trust with a whole document, since the structural gate catches malformed output but not a quality regression.

<details>
<summary>中文</summary>

翻译 agent 会稳定地在行内代码块内侧多打一个空格:模型给出 `` ` @qwen-code/webui` ``,而文档里是 `` `@qwen-code/webui` ``。锚点因此匹配不到任何内容;又因为补丁是全或无的,**一条坏锚点就会丢弃整篇文档的翻译**,该文件第二天重新出现,表现为 `target not touched this session` —— 正是 #260 开篇描述的症状。

**这值多少**:运行 34412117469 是保留 agent 日志(#264)后的第一次,锚点终于可读。其 56 个被拒补丁集中,17 个源于本文所修的代码块畸变,37 个的锚点在目标文件和英文原文里都不存在,1 个是多次匹配,1 个因文件此后变动而现已可匹配。此处每个数字均由已提交的函数算出 —— 本描述早先版本写的是 20,来自刻画失败时使用的更宽诊断归一化,未针对最终代码重新推导。零匹配以 54/56 占绝对多数,并且干净地分成"机械的一半"和"语义的一半",本 PR 修的是机械那半。

**验证**:用本 PR 提交的函数本体(而非重新实现)重放该次运行的真实 agent 输出。**挽回 15 篇文档**(现行逻辑 1 篇能套上,加回退后 16 篇)。**对已经成功的毫无影响**:重放该次运行中成功的 153 个补丁集,加与不加回退输出逐字节相同 —— 这是结构性的而非运气:回退只在 `indexOf` 已返回 -1、补丁集即将被丢弃时才执行。

**为什么修锚点而不是改提示词**:`prompts/translate.md` 第 8 行从一开始就要求逐字复制且恰好出现一次,这 20 次失败正是在该指令下发生的。提示词不是缺口所在。

**值得复看的细节**:`new` 同样修复(它带有相同畸变,原样写入会把畸形代码块发布到页面上);只处理同一行内闭合的代码块、且跳过围栏内部,因此 `` `foo` bar `` 的空格得以保留 —— 那个空格属于两个代码块**之间**的正文,恰是朴素的 `` /`\s+/ `` 正则会破坏的情形;无单元测试,因为 `applyTranslationPatches` 只能经由真实模型调用触达,与其为一个测试缝重构模块,不如以上述重放为证据 —— 它针对 209 个真实补丁集运行了已提交的函数。

**不在范围内**:另外 34 个锚点在任何地方都不存在的情形 —— 模型是在凭印象复述目标文本(锚点长度中位 199 字符)。那需要另一种解法(很可能是降级为整文件重写),并且涉及本 PR 刻意不做的判断:一个连准确复制都做不到的模型,是否值得托付整篇文档 —— 结构闸门能拦住畸形输出,却拦不住质量倒退。

</details>

Ref #260.

https://claude.ai/code/session_01Sa8YZQrbc74Rdsfbhibkjy

