### PR TITLE
ci: regenerate a navigation _meta.ts from the English one

### DIFF
--- a/.github/scripts/check-nav-keys.mjs
+++ b/.github/scripts/check-nav-keys.mjs
@@ -1,0 +1,42 @@
+// Compares the route keys of each locale's navigation file against English.
+// Prints one line per locale that disagrees, and nothing at all when they
+// all match, so the caller can test with `[ -s report ]`.
+//
+// Separator entries are skipped: `{ type: 'separator' }` uses its key as a
+// display label rather than a route, so a translated one is correct.
+//
+// Run from website/. FILE is relative to content/en, LANGS is space-separated.
+import fs from "node:fs";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const file = process.env.FILE;
+const langs = (process.env.LANGS || "").split(/\s+/).filter(Boolean);
+
+const routeKeys = (p) => {
+  const mod = require(p);
+  const obj = mod.default || mod;
+  return Object.keys(obj).filter((k) => {
+    const v = obj[k];
+    return !(v && typeof v === "object" && v.type === "separator");
+  });
+};
+
+const en = routeKeys(`${process.cwd()}/content/en/${file}`);
+for (const lang of langs) {
+  const p = `${process.cwd()}/content/${lang}/${file}`;
+  if (!fs.existsSync(p)) continue;
+  let keys;
+  try {
+    keys = routeKeys(p);
+  } catch (err) {
+    console.log(`${lang}: cannot be loaded — ${err.message}`);
+    continue;
+  }
+  const missing = en.filter((k) => !keys.includes(k));
+  const extra = keys.filter((k) => !en.includes(k));
+  if (missing.length || extra.length)
+    console.log(
+      `${lang}: missing [${missing.join(", ")}] unexpected [${extra.join(", ")}]`
+    );
+}

--- a/.github/workflows/regenerate-nav-meta.yml
+++ b/.github/workflows/regenerate-nav-meta.yml
@@ -1,0 +1,123 @@
+# Regenerates a localized navigation file (`_meta.ts`) from the English one.
+#
+# translator/src/sync.ts deliberately skips every `_meta.*` when copying
+# upstream docs, because this site has tabs upstream does not. Navigation is
+# therefore a manual mirror, and it drifts: #263 found `developers/_meta.ts`
+# missing entries in every locale, and absent entirely for `ko`.
+#
+# `qwen-translation meta` fixes that, but running it by hand has four traps
+# this workflow removes:
+#
+#   1. It needs model credentials. They live in this repo as
+#      TRANSLATE_CODING_PLAN_API_KEY; running locally spends the operator's own.
+#   2. Bare `meta` translates all 18 `_meta.ts` files into 7 locales -- 126
+#      model calls that overwrite every curated navigation file to fix one.
+#      `-f` is mandatory below, so the blast radius is the file you name.
+#   3. translation.config.json is resolved from the cwd and lives in website/.
+#      Run it from the repo root and the config is not found; the fallback
+#      target list in meta-translator.ts is then used, which contains `es`
+#      (a locale this site does not have) and omits `ja` (one it does).
+#   4. bin/qwen-translator requires ../dist, which is not committed.
+#
+# The result arrives as a PR, never a direct push: an LLM writing a `_meta.ts`
+# can translate the KEYS as well as the values, and a wrong key silently drops
+# the page from the sidebar. That diff needs eyes.
+
+name: Regenerate navigation meta
+
+on:
+  workflow_dispatch:
+    inputs:
+      file:
+        description: "Meta file, relative to website/content/en (e.g. developers/_meta.ts)"
+        required: true
+        default: "developers/_meta.ts"
+      languages:
+        description: "Space-separated locales"
+        required: true
+        default: "zh de fr ru ja pt-BR ko"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: regenerate-nav-meta
+  cancel-in-progress: false
+
+jobs:
+  regenerate:
+    name: Translate one _meta.ts into each locale
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: translator/package-lock.json
+
+      - name: Build the translator CLI
+        working-directory: ./translator
+        run: |
+          npm ci --no-audit --no-fund
+          npm run build
+
+      - name: Translate
+        working-directory: ./website
+        env:
+          OPENAI_API_KEY: ${{ secrets.TRANSLATE_CODING_PLAN_API_KEY }}
+          OPENAI_BASE_URL: ${{ vars.TRANSLATE_BASE_URL || 'https://coding.dashscope.aliyuncs.com/v1' }}
+          QWEN_MODEL: ${{ vars.QWEN_MODEL || 'qwen3.7-plus' }}
+          FILE: ${{ inputs.file }}
+          LANGS: ${{ inputs.languages }}
+        run: |
+          set -euo pipefail
+          if [ -z "${FILE// }" ]; then
+            echo "::error::file is required; a bare \`meta\` run would rewrite every navigation file"
+            exit 1
+          fi
+          if [ ! -f "content/en/${FILE}" ]; then
+            echo "::error::content/en/${FILE} does not exist"
+            exit 1
+          fi
+          for lang in $LANGS; do
+            echo "::group::${FILE} -> ${lang}"
+            node ../translator/dist/cli.js meta -f "${FILE}" -l "${lang}"
+            echo "::endgroup::"
+          done
+
+      - name: Open a PR with the result
+        env:
+          GH_TOKEN: ${{ secrets.TRANSLATION_BOT_PAT }}
+          FILE: ${{ inputs.file }}
+          LANGS: ${{ inputs.languages }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "::error::secret TRANSLATION_BOT_PAT is empty or not set; cannot open the PR"
+            exit 1
+          fi
+          git config user.name "qwen-docs-bot"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add website/content
+          if git diff --cached --quiet; then
+            echo "::warning::every locale already matched the English navigation; nothing to propose"
+            exit 0
+          fi
+          branch="automation/nav-meta-${GITHUB_RUN_ID}"
+          git commit -m "docs(nav): regenerate ${FILE} for ${LANGS}"
+          git push origin "HEAD:${branch}"
+          body="$(printf '%s\n' \
+            "Regenerated \`${FILE}\` for: ${LANGS}." \
+            "" \
+            "From run ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}." \
+            "" \
+            "Check the keys, not just the values. An LLM writing a \`_meta.ts\` can translate the keys too, and a wrong key drops the page from the sidebar without any build error.")"
+          gh pr create --repo "$GITHUB_REPOSITORY" \
+            --base main --head "${branch}" \
+            --title "docs(nav): regenerate ${FILE}" \
+            --body "${body}"

--- a/.github/workflows/regenerate-nav-meta.yml
+++ b/.github/workflows/regenerate-nav-meta.yml
@@ -67,6 +67,7 @@ jobs:
           npm run build
 
       - name: Translate
+        id: translate
         working-directory: ./website
         env:
           OPENAI_API_KEY: ${{ secrets.TRANSLATE_CODING_PLAN_API_KEY }}
@@ -84,17 +85,59 @@ jobs:
             echo "::error::content/en/${FILE} does not exist"
             exit 1
           fi
+          # One locale failing must not discard the ones that already
+          # succeeded. Under `set -e` the step would abort, "Open a PR" would
+          # be skipped for having a failed predecessor, and every translation
+          # produced so far would leave with the runner. Collect instead, and
+          # let the last step decide the run's colour.
+          done_langs=""
+          failed_langs=""
           for lang in $LANGS; do
             echo "::group::${FILE} -> ${lang}"
-            node ../translator/dist/cli.js meta -f "${FILE}" -l "${lang}"
+            if node ../translator/dist/cli.js meta -f "${FILE}" -l "${lang}"; then
+              done_langs="${done_langs} ${lang}"
+            else
+              failed_langs="${failed_langs} ${lang}"
+              echo "::warning::${lang} failed; continuing with the remaining locales"
+            fi
             echo "::endgroup::"
           done
+          {
+            echo "done=${done_langs# }"
+            echo "failed=${failed_langs# }"
+          } >> "$GITHUB_OUTPUT"
+
+      # A translated KEY is the failure that costs a page: Nextra routes on
+      # the key, so `tools:` becoming `outils:` drops the section from the
+      # sidebar with no build error and no runtime error. Asking a reviewer to
+      # "check the keys" across seven locales is asking a person to run a
+      # diff; run it mechanically instead.
+      #
+      # Separator entries are exempt. Their key is a display label rather than
+      # a route, so translating `'Qwen Code SDK'` is correct, and comparing it
+      # would report a mismatch on every locale.
+      - name: Check navigation keys against English
+        id: keys
+        working-directory: ./website
+        env:
+          FILE: ${{ inputs.file }}
+          LANGS: ${{ steps.translate.outputs.done }}
+        run: |
+          set -uo pipefail
+          node ../.github/scripts/check-nav-keys.mjs > key-report.txt || true
+          if [ -s key-report.txt ]; then
+            while IFS= read -r line; do echo "::error::${FILE}: ${line}"; done < key-report.txt
+            echo "mismatch=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "mismatch=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Open a PR with the result
         env:
           GH_TOKEN: ${{ secrets.TRANSLATION_BOT_PAT }}
           FILE: ${{ inputs.file }}
-          LANGS: ${{ inputs.languages }}
+          DONE: ${{ steps.translate.outputs.done }}
+          FAILED: ${{ steps.translate.outputs.failed }}
         run: |
           set -euo pipefail
           if [ -z "${GH_TOKEN}" ]; then
@@ -109,15 +152,35 @@ jobs:
             exit 0
           fi
           branch="automation/nav-meta-${GITHUB_RUN_ID}"
-          git commit -m "docs(nav): regenerate ${FILE} for ${LANGS}"
+          git commit -m "docs(nav): regenerate ${FILE} for ${DONE}"
           git push origin "HEAD:${branch}"
+          # printf arguments rather than a multi-line literal: an unindented
+          # continuation line would terminate the YAML block scalar above.
+          report="$(cat website/key-report.txt 2>/dev/null || true)"
+          if [ -n "$report" ]; then
+            keyline="Route-key check FAILED. These drop pages from the sidebar and must be fixed before merging: ${report}"
+            suffix=" (key mismatch)"
+          else
+            keyline="Route keys match the English file. Separator keys are exempt: their key is a label, not a route."
+            suffix=""
+          fi
           body="$(printf '%s\n' \
-            "Regenerated \`${FILE}\` for: ${LANGS}." \
+            "Regenerated \`${FILE}\` for: ${DONE:-none}." \
             "" \
-            "From run ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}." \
+            "${FAILED:+Failed, and therefore absent from this PR: ${FAILED}}" \
             "" \
-            "Check the keys, not just the values. An LLM writing a \`_meta.ts\` can translate the keys too, and a wrong key drops the page from the sidebar without any build error.")"
+            "${keyline}" \
+            "" \
+            "From run ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}.")"
           gh pr create --repo "$GITHUB_REPOSITORY" \
             --base main --head "${branch}" \
-            --title "docs(nav): regenerate ${FILE}" \
+            --title "docs(nav): regenerate ${FILE}${suffix}" \
             --body "${body}"
+
+      # Last, so a failed locale or a drifted key still leaves the PR behind
+      # to work from: red run, preserved work.
+      - name: Fail if a locale failed or a key drifted
+        if: steps.translate.outputs.failed != '' || steps.keys.outputs.mismatch == 'true'
+        run: |
+          echo "::error::failed locales: '${{ steps.translate.outputs.failed }}'; key mismatch: ${{ steps.keys.outputs.mismatch }}"
+          exit 1


### PR DESCRIPTION
Unblocks the half of #263 that needs a maintainer: regenerating the localized `_meta.ts` files. Dispatch it from the Actions tab instead of running the CLI by hand.

## Why navigation drifts at all

`translator/src/sync.ts` deliberately skips every `_meta.*` when copying upstream docs, because this site has tabs (`showcase`, `blog`) that do not exist upstream. Navigation is ours, which also means it is a **manual mirror** — and it has drifted. #263 found `developers/_meta.ts` missing entries in every locale, and missing entirely for `ko`.

## Four traps this removes

Running `qwen-translation meta` by hand is not one command, and three of these fail quietly:

1. **Credentials.** It calls an OpenAI-compatible endpoint with `OPENAI_API_KEY`. This repo already holds one as `TRANSLATE_CODING_PLAN_API_KEY`; running locally spends the operator's own quota instead.
2. **A bare `meta` is not what you want.** It translates all 18 `_meta.ts` files into 7 locales — **126 model calls that overwrite every curated navigation file** to fix one. `-f` is mandatory here, so the blast radius is the file you name, and the job fails fast if it is empty or does not exist.
3. **`translation.config.json` resolves from the cwd, and lives in `website/`.** Run from the repo root and it is not found — at which point `meta-translator.ts` falls back to a hardcoded target list containing `es`, a locale this site does not have, and omitting `ja`, one it does. The workflow pins the working directory.
4. **`bin/qwen-translator` requires `../dist`**, which is not committed. The build step is part of the job.

## The result is a PR, never a push

An LLM writing a `_meta.ts` can translate the **keys** as well as the values, and a wrong key drops the page from the sidebar with no build error at all. That diff needs eyes, so it arrives as a PR opened with `TRANSLATION_BOT_PAT`, and the PR body says what to look for.

## Usage

Actions → **Regenerate navigation meta** → Run workflow. Defaults are `developers/_meta.ts` and `zh de fr ru ja pt-BR ko` — exactly what #263 needs. Both are inputs, so it stays useful the next time upstream navigation moves.

## Verified

`npm ci && npm run build` in `translator/` produces `dist/cli.js`, and `meta --help` reports the `-f` / `-l` flags this passes:

```
Options:
  -l, --language <lang>  Specify target language
  -f, --file <file>      Specify _meta.ts file to translate
```

Both run scripts pass `bash -n`. The model calls themselves are not exercised until someone dispatches it.

## Still #263's call, not this PR's

Whether to keep its second commit (un-hiding `examples`) is a judgement about matching upstream, and no automation settles it.

<details>
<summary>中文</summary>

解开 #263 中需要维护者亲自动手的那一半:重新生成各语言的 `_meta.ts`。从 Actions 页面点一下即可,不必手跑 CLI。

**导航为何会漂移**:`translator/src/sync.ts` 在拷贝上游文档时刻意跳过所有 `_meta.*`,因为本站有上游没有的 tab(`showcase`、`blog`),导航归本站所有 —— 代价是它成了**手工镜像**,并且已经漂移。

**本 workflow 消除的四个坑**(其中三个是静默失败):(1) 需要模型凭据,而本仓库已有 `TRANSLATE_CODING_PLAN_API_KEY`,本地跑则消耗操作者自己的额度;(2) 裸跑 `meta` 会把全部 18 个文件翻成 7 种语言 —— **126 次模型调用、覆盖所有精心编排过的导航文件**,只为修一个,因此这里 `-f` 是必填,为空或文件不存在即快速失败;(3) `translation.config.json` 按 cwd 解析且位于 `website/`,在仓库根目录跑会找不到,进而回落到 `meta-translator.ts` 里的硬编码语言表 —— 那份表含本站没有的 `es`、且漏掉本站有的 `ja`;(4) `bin/qwen-translator` 依赖未提交的 `../dist`,构建已并入本 job。

**产物是 PR 而非直接推送**:LLM 写 `_meta.ts` 时可能把 **key** 也一并翻译,而 key 错误会让页面从侧栏消失且**不产生任何构建错误**。这种 diff 必须有人过目,因此用 `TRANSLATION_BOT_PAT` 开 PR,并在正文里写明该看什么。

**用法**:Actions → Regenerate navigation meta → Run workflow。默认值为 `developers/_meta.ts` 与 `zh de fr ru ja pt-BR ko`,正是 #263 所需;两者都是输入项,下次上游导航变动仍可复用。

**已验证**:`translator/` 下 `npm ci && npm run build` 能产出 `dist/cli.js`,`meta --help` 报告的正是本 workflow 传入的 `-f` / `-l`;两段 run 脚本均通过 `bash -n`。模型调用本身要等有人真正 dispatch 才会执行。

**仍属 #263 的判断题**:是否保留其第 2 个提交(取消隐藏 `examples`)是与上游是否对齐的取舍,自动化解决不了。

</details>

Ref #263.

https://claude.ai/code/session_01Sa8YZQrbc74Rdsfbhibkjy
