### PR TITLE
ci: run the structural gate on pull requests

### DIFF
--- a/.github/workflows/translation-gate.yml
+++ b/.github/workflows/translation-gate.yml
@@ -1,0 +1,68 @@
+# Runs the nightly's own structural gate on the files a pull request changes.
+#
+# The nightly gates everything it writes, so its PRs arrive pre-checked.
+# Human-authored PRs that touch website/content do not: blog posts, showcase
+# entries and hand-written translations reach main with no structural
+# verification at all. #268 is the shape of what gets through -- a table left
+# in English inside a German page, a tool list that lost two entries.
+#
+# It calls `orchestrator.mjs check`, which uses the same structuralProblems()
+# the nightly uses. Two copies of a gate drift; one does not.
+#
+# Only the PR's own files are checked. The repository carries pre-existing
+# gate failures (#260) and a check that reported those on an unrelated PR
+# would be switched off within a week.
+#
+# What it cannot see: whether the prose is *correctly* translated. #268's two
+# reversed sentences pass every check here. This catches the mechanical half
+# and makes no claim on the other.
+
+name: Translation gate
+
+on:
+  pull_request:
+    paths:
+      - "website/content/**"
+      - "translator/orchestrator/orchestrator.mjs"
+      - ".github/workflows/translation-gate.yml"
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: translation-gate-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  gate:
+    name: Structural gate on changed pages
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Check the pages this PR changes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          # Removed files would fail the existence check anyway, but asking for
+          # them makes the log read as if they were skipped for being English.
+          files="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR}/files" --paginate \
+            --jq '.[] | select(.status != "removed") | .filename' \
+            | grep '^website/content/' || true)"
+          if [ -z "$files" ]; then
+            echo "No content pages changed."
+            exit 0
+          fi
+          echo "$files" | sed 's/^/  /'
+          node translator/orchestrator/orchestrator.mjs check \
+            --files "$(echo "$files" | paste -sd,)"

--- a/translator/orchestrator/orchestrator.mjs
+++ b/translator/orchestrator/orchestrator.mjs
@@ -1424,6 +1424,104 @@ function cmdQuarantine() {
   }
 }
 
+/**
+ * Prose lines long enough that an identical copy in the target means the line
+ * was never translated, rather than that both languages happen to agree.
+ *
+ * Fenced blocks are skipped wholesale: code, terminal transcripts, mermaid
+ * diagrams and agent-prompt examples are *supposed* to match the source, and
+ * counting them buried the real signal under 41 false positives when this was
+ * first measured. Headings and blockquotes are skipped for being short and
+ * often proper nouns; table rows are kept, because a table of English option
+ * descriptions inside an otherwise translated page is exactly the case worth
+ * catching (#268). Inline code and link targets are removed before counting
+ * words, so a line is only prose if eight or more plain Latin words survive.
+ */
+function untranslatedProse(text) {
+  const lines = [];
+  let fenced = false;
+  for (const raw of text.split("\n")) {
+    const line = raw.trim();
+    if (/^(```|~~~)/.test(line)) {
+      fenced = !fenced;
+      continue;
+    }
+    if (fenced) continue;
+    if (line.length < 60) continue;
+    if (/^[#>]/.test(line)) continue;
+    if (/^\|[\s:|-]+\|?$/.test(line)) continue;
+    const words = line
+      .replace(/`[^`]*`/g, "")
+      .replace(/\[[^\]]*\]\([^)]*\)/g, "")
+      .split(/\s+/)
+      .filter((w) => /^[A-Za-z][A-Za-z,.;:'()-]*$/.test(w));
+    if (words.length >= 8) lines.push(line);
+  }
+  return lines;
+}
+
+/**
+ * Run the structural gate over an explicit list of files, for use on a pull
+ * request rather than inside a nightly run.
+ *
+ * The nightly already gates everything it writes, so automation PRs arrive
+ * pre-checked. Human-authored PRs that touch `website/content` do not: blog
+ * posts, showcase entries and hand-written translations reach `main` with no
+ * structural verification at all. This is the same `structuralProblems()` the
+ * nightly uses -- deliberately the same function, so the two cannot drift.
+ *
+ * Only the files named are checked. The repository carries pre-existing gate
+ * failures (#260), and a checker that reports those on an unrelated PR would
+ * be turned off within a week.
+ */
+function cmdCheck(files) {
+  const list = (files || "")
+    .split(/[,\n]/)
+    .map((f) => f.trim())
+    .filter(Boolean);
+  if (!list.length) {
+    console.log("[orch] check: no files given, nothing to do");
+    return;
+  }
+  let checked = 0;
+  let bad = 0;
+  for (const file of list) {
+    const rel = file.replace(/^website\/content\//, "");
+    const slash = rel.indexOf("/");
+    if (slash < 0) continue;
+    const lang = rel.slice(0, slash);
+    const inLang = rel.slice(slash + 1);
+    if (lang === "en") continue;
+    if (!/\.mdx?$/.test(inLang)) continue;
+    const target = path.join(OPTS.contentDir, lang, inLang);
+    const source = path.join(OPTS.contentDir, "en", inLang);
+    // A page with no English counterpart is locale-only content, not a
+    // translation: there is nothing to compare it against.
+    if (!fs.existsSync(target) || !fs.existsSync(source)) continue;
+    checked++;
+    const en = fs.readFileSync(source, "utf8");
+    const tg = fs.readFileSync(target, "utf8");
+    const problems = structuralProblems(en, tg, lang);
+    // Reported, never fatal: this one is a heuristic, and the codebase
+    // already spells a soft finding `WARN` (see verifyFile's link count).
+    const sourceProse = new Set(untranslatedProse(en));
+    const copied = untranslatedProse(tg).filter((l) => sourceProse.has(l));
+    if (copied.length) {
+      console.log(
+        `::warning file=${file}::${copied.length} line(s) identical to the English source; first: ${copied[0].slice(0, 120)}`
+      );
+      console.log(`WARN ${file}: ${copied.length} line(s) look untranslated`);
+    }
+    if (!problems.length) continue;
+    bad++;
+    for (const problem of problems)
+      console.log(`::error file=${file}::${problem}`);
+    console.log(`FAIL ${file}: ${problems.join("; ")}`);
+  }
+  console.log(`[orch] check: ${checked} file(s) checked, ${bad} failed`);
+  if (bad) process.exitCode = 1;
+}
+
 function cmdReportBatch() {
   const logDir = path.resolve(flags["log-dir"] || "/tmp");
   const logs = fs.existsSync(logDir)
@@ -1549,6 +1647,9 @@ switch (cmd) {
   case "quarantine":
     cmdQuarantine();
     break;
+  case "check":
+    cmdCheck(flags.files);
+    break;
   case "report-batch":
     cmdReportBatch();
     break;
@@ -1557,7 +1658,7 @@ switch (cmd) {
     break;
   default:
     console.log(
-      "usage: orchestrator.mjs <detect|preflight|sync-en|seed|translate|verify|scan|advance|quarantine|report-batch|report> [--lang L] [--limit N] [--content-dir D] [--baseline B] [--manifest M] [--langs csv]"
+      "usage: orchestrator.mjs <detect|preflight|sync-en|seed|translate|verify|scan|advance|quarantine|check|report-batch|report> [--lang L] [--limit N] [--content-dir D] [--baseline B] [--manifest M] [--langs csv] [--files csv]"
     );
     process.exitCode = cmd ? 1 : 0;
 }


### PR DESCRIPTION
The nightly gates everything it writes, so its own PRs arrive pre-checked. **Human-authored PRs touching `website/content` are checked by nothing at all** — blog posts, showcase entries and hand-written translations reach `main` with no structural verification. #268 is the shape of what gets through: a table left in English inside a German page, a tool list that lost two entries.

## What it runs

`orchestrator.mjs check --files` — the same `structuralProblems()` the nightly uses, fed the files the PR changes. Deliberately the same function: two copies of a gate drift, one does not. So a PR gets fence parity against the English source, frontmatter validity, and the source-language contamination scan.

**Only the PR's own files.** The repository carries pre-existing gate failures (#260); a check that reported those on an unrelated PR would be switched off within a week.

## Plus one new check, and the measurement that shaped it

It also reports lines **byte-identical to the English source** — which is what an untranslated paragraph looks like.

The first version of this counted every line and was useless: **41 files flagged, 40 of them noise.** Code comments, mermaid edges (`MW->>MW: remote same-origin Origin strip…`), terminal transcripts, agent-prompt examples — all inside fenced blocks, all *supposed* to match the source.

Excluding fenced blocks wholesale, and requiring eight or more plain Latin words after inline code and link targets are stripped, changes the result completely. Run over the 139 content files #268 changed:

```
WARN de/developers/daemon/15-channel-adapters.md: 2 line(s) look untranslated
WARN de/users/features/channels/overview.md: 3 line(s) look untranslated
[orch] check: 139 file(s) checked, 0 failed
```

Those are **exactly** the two untranslated-prose findings the review of #268 raised, and there is nothing else — no false positives across 139 files.

Table rows are kept rather than skipped, and that is what catches the first of the two: a table of English option descriptions inside an otherwise German page.

Soft by design. It is a heuristic, and `WARN` is already how `verifyFile` spells a finding that should not fail the gate.

## What it does not do — measured, not assumed

**It would not have failed #268.** Run against that batch before the fixes: `139 file(s) checked, 0 failed`. Every structural check passes. The two sentences whose *meaning* was wrong —

- `fr/.../github.md` dropping the `no-write` qualifier
- `ko/.../dingtalk.md` reversing which thing replaces which

— are fluent, well-formed, correctly-fenced translations that happen to say something the source does not. Nothing mechanical sees that. This PR catches the mechanical half and the copied-line case, and makes no claim on the rest.

## Cost

No model calls. It is a file read and a string compare, on `pull_request` only, scoped to `website/content/**` and the orchestrator itself.

<details>
<summary>中文</summary>

nightly 会对自己写入的一切进行结构校验,所以它的 PR 是预先检查过的。**而人工撰写、触及 `website/content` 的 PR 完全没有任何检查** —— 博客、showcase 条目、手写译文直接进入 `main`。#268 就是漏网之鱼的形态:德语页面里整张英文表格、少了两项的工具列表。

**运行什么**:`orchestrator.mjs check --files` —— 与 nightly 使用的**同一个** `structuralProblems()`,输入是该 PR 改动的文件。刻意复用同一函数:两份闸门会漂移,一份不会。于是 PR 获得围栏对齐、frontmatter 有效性、源语言污染扫描。**只检查该 PR 自己的文件**,因为仓库存有既有失败(#260),一个在无关 PR 上报告这些的检查活不过一周。

**外加一项新检查,以及塑造它的实测**:另报告与英文源**逐字节相同**的行 —— 未翻译段落就长这样。第一版逐行统计,毫无用处:**41 个文件被标记,其中 40 个是噪音** —— 代码注释、mermaid 连线、终端回放、提示词示例,全在围栏内,而且本就**应当**与源相同。整体排除围栏、并要求剥除行内代码与链接后仍有 8 个以上纯拉丁词之后,结果完全不同:对 #268 改动的 139 个内容文件运行,只报出 2 个文件,**恰好就是评审提出的那两处未翻译散文**,再无其他 —— 139 个文件零误报。表格行被保留而非跳过,正是它抓住了第一处:德语页面里一整张英文选项说明表。设计为软告警:它是启发式,而 `WARN` 本就是 `verifyFile` 表示「不应导致闸门失败的发现」的写法。

**它做不到什么 —— 实测而非假设**:**它不会让 #268 变红**。对修复前的该批次运行:`139 file(s) checked, 0 failed`,所有结构检查全过。那两句**语义**错误的译文 —— `fr/.../github.md` 丢掉 `no-write` 限定、`ko/.../dingtalk.md` 把两者关系颠倒 —— 是流畅、格式正确、围栏对齐的译文,只是说了源文本没说的意思。任何机械检查都看不见。本 PR 只解决机械的那一半与整行照抄的情形,对其余不作任何声称。

**成本**:零模型调用,只是文件读取与字符串比较;仅在 `pull_request` 上触发,路径限定为 `website/content/**` 与 orchestrator 自身。

</details>

Ref #268, #260.

https://claude.ai/code/session_01Sa8YZQrbc74Rdsfbhibkjy
