### PR TITLE
fix(ci): stop [skip ci] suppressing checks on the generated PR

### DIFF
--- a/.github/workflows/daily-translate.yml
+++ b/.github/workflows/daily-translate.yml
@@ -283,7 +283,17 @@ jobs:
           if git diff --cached --quiet; then
             echo "::warning::nothing verified to commit this run — check the agent logs above"
           else
-            git commit -m "docs(i18n): daily incremental translation sync [skip ci]"
+            # No `[skip ci]`. It dates from when this job pushed straight to
+            # main and had to stop deploy-docs.yml running twice. Since #201
+            # the work goes to a branch and then a PR, and nothing watches a
+            # push to `automation/*` -- but GitHub honours the marker on
+            # `pull_request` events too, so it silently suppressed every check
+            # on the generated PR, the structural gate (#271) included. PR
+            # #272 opened with no checks at all because of this line.
+            #
+            # The merge commit carries no marker, so deploy-docs.yml still
+            # runs when the PR lands.
+            git commit -m "docs(i18n): daily incremental translation sync"
             branch="automation/daily-translation-${GITHUB_RUN_ID}"
             git push origin "HEAD:${branch}"
             run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"

--- a/scripts/check-nightly-translation.sh
+++ b/scripts/check-nightly-translation.sh
@@ -18,9 +18,31 @@ set -uo pipefail
 R="${REPO:-QwenLM/qwen-code-docs}"
 BOT="${BOT_LOGIN:-qwen-code-review-bot}"
 
-read -r id st cc < <(gh run list --repo "$R" --workflow "Daily Incremental Translation" \
-  --limit 1 --json databaseId,status,conclusion \
-  --jq '"\(.[0].databaseId) \(.[0].status) \(.[0].conclusion // "-")"')
+# Not simply the newest run. A run that finds a translation PR still open
+# skips its model work and produces no branch, and reporting on that one made
+# the script announce "opened by a human" for a batch it had never looked at.
+# Walk back to the newest run that actually produced a batch.
+id=""
+skipped=0
+while read -r candidate; do
+  [ -n "$candidate" ] || continue
+  if gh api "repos/$R/branches/automation/daily-translation-$candidate" -q .name >/dev/null 2>&1 ||
+     [ -n "$(gh pr list --repo "$R" --state all --head "automation/daily-translation-$candidate" \
+       --limit 1 --json number --jq '.[0].number // empty')" ]; then
+    id="$candidate"
+    break
+  fi
+  skipped=$((skipped + 1))
+done < <(gh run list --repo "$R" --workflow "Daily Incremental Translation" \
+  --limit 6 --json databaseId --jq '.[].databaseId')
+
+if [ -z "$id" ]; then
+  echo "run : none of the last 6 runs produced a batch — all skipped, or all quiet"
+  exit 0
+fi
+[ "$skipped" -eq 0 ] || echo "note: skipped $skipped later run(s) that produced no batch (paused on an open PR)"
+
+read -r st cc < <(gh api "repos/$R/actions/runs/$id" --jq '"\(.status) \(.conclusion // "-")"')
 branch="automation/daily-translation-$id"
 echo "run : $id  $st/$cc   https://github.com/$R/actions/runs/$id"
 


### PR DESCRIPTION
Two bugs the 2026-09-10 runs exposed. Both are mine, both from the last two days.

## `[skip ci]` suppressed every check on the generated PR

PR #272 was opened by the nightly and arrived with **zero checks**:

```
$ gh run list --repo … | grep automation/daily-translation-34462813835
(nothing)
```

Not the structural gate from #271, not anything. The cause is the marker in the commit message:

```
docs(i18n): daily incremental translation sync [skip ci]
```

GitHub honours `[skip ci]` on `pull_request` events, not only on `push`. So the one PR the gate has the most to look at — a hundred-odd machine-translated files — is the one PR it can never run on.

The marker is vestigial. It dates from when this job pushed straight to `main` and had to stop `deploy-docs.yml` building twice. Since #201 the work goes to a branch and then a PR, and **nothing watches a push to `automation/*`**:

| workflow | triggers |
| --- | --- |
| `deploy-docs.yml` | push to `main` |
| `tests.yml` | pull_request, push to `main` |
| `translation-gate.yml` | pull_request |
| `regenerate-nav-meta.yml` | workflow_dispatch |
| `daily-translate.yml` | schedule, workflow_dispatch |

Removed. The merge commit carries no marker, so `deploy-docs.yml` still runs when the PR lands — which is how the last several batches deployed anyway.

## The check script reported on a run that had done nothing

```
PR  : #null null by null  <-- opened by a human, not the workflow
```

It took the newest run unconditionally. A run that finds a translation PR still open skips its model work and produces no branch — by design, and it costs nothing. Today a second dispatch was paused that way by the open #272, so the script looked for a branch named after a run that never made one, found nothing, and announced "opened by a human" about a batch it had never looked at.

It now walks back to the newest run that actually produced a batch, and says how many it stepped over:

```
note: skipped 1 later run(s) that produced no batch (paused on an open PR)
run : 34462813835  completed/success
PR  : #272 MERGED by qwen-code-review-bot  <-- OK, the run opened it itself
open: 0 translation PR(s)
base: last-sync 2026-09-10 (0d old)
```

Worth noting the failure mode this had: it reported a **false negative on the good case** — the automation had worked perfectly and the script said a human did it. A checker that cries wolf about its own subject is worse than no checker.

<details>
<summary>中文</summary>

2026-09-10 的运行暴露出的两个 bug,都是我这两天引入的。

**`[skip ci]` 压制了生成 PR 上的全部检查**:PR #272 由 nightly 开出,**没有任何检查运行** —— #271 的结构闸门也没跑。原因是 commit message 里的标记:GitHub 对 `pull_request` 事件同样遵循 `[skip ci]`,不只是 `push`。于是闸门最该检查的那个 PR(一百多个机器翻译文件),恰恰是它永远跑不到的那个。

该标记是历史遗留:它源于本 job 当年直推 `main`、需要阻止 `deploy-docs.yml` 重复构建的时期。自 #201 起工作走分支再走 PR,而**没有任何 workflow 监听 `automation/*` 的 push**(见上表)。已移除。合并产生的 merge commit 不带该标记,所以 PR 落地时 `deploy-docs.yml` 照常运行 —— 最近几批本来就是这么部署的。

**检查脚本对一次什么都没做的运行下了结论**:它无条件取最新一次运行。而一次发现仍有翻译 PR 未合的运行会跳过模型工作、不产生分支(这是设计,且零开销)。今天第二次 dispatch 正是被尚未合并的 #272 拦下,于是脚本去找一个从未被创建的分支,找不到,便对一批它根本没看过的内容宣称"是人工建的"。现在它会回溯到最近一次真正产出批次的运行,并说明跳过了几次。

值得记下它的失败形态:这是**对正常情况的假阴性** —— 自动化明明工作正常,脚本却说是人做的。一个对自己监测对象误报的检查器,比没有检查器更糟。

</details>

Ref #271, #272.

https://claude.ai/code/session_01Sa8YZQrbc74Rdsfbhibkjy
