### PR TITLE
feat(orchestrator): translate large documents one slice at a time

### DIFF
--- a/translator/orchestrator/orchestrator.mjs
+++ b/translator/orchestrator/orchestrator.mjs
@@ -442,7 +442,126 @@ function cmdSyncEn() {
   console.log(`[orch] sync-en: copied=${copied} deleted=${deleted}`);
 }
 
-function renderPrompt(lang, batch) {
+// A document whose English source is larger than this is translated one
+// slice at a time. The number is measured, not guessed: in run 34462813835
+// every source above 47KB failed with a truncated JSON response, and every
+// one at 29KB or below succeeded. 40KB sits in that gap.
+const SECTION_SPLIT_BYTES = 40000;
+// Each slice stays under the largest source that has been translated whole.
+const SECTION_BUDGET_BYTES = 30000;
+
+/**
+ * Split a markdown document at heading boundaries, greedily packing sections
+ * up to SECTION_BUDGET_BYTES.
+ *
+ * The failure this exists for is an output limit, not an input one: the model
+ * has to emit the translated text of everything it is asked to change, and
+ * for the four documents that dominate the backlog that response reached
+ * 90-177KB and was cut mid-string, discarding the whole document's work. In
+ * run 34462813835 that was 45 of 53 failures, and `users/configuration/
+ * settings.md`, `model-providers.md`, `users/qwen-serve.md` and
+ * `daemon/02-serve-runtime.md` between them accounted for 26 of them, every
+ * night, for weeks.
+ *
+ * Fences are tracked so a `## ` inside a code block is not a boundary. A
+ * section that is over budget on its own is split again at `### `, and if it
+ * is still over budget it is emitted whole -- a slice that is too large is
+ * still strictly better than sending the entire document.
+ */
+function splitSections(text, budget = SECTION_BUDGET_BYTES) {
+  const cut = (body, marker) => {
+    const parts = [];
+    let current = [];
+    let fenced = false;
+    for (const line of body.split("\n")) {
+      if (/^\s*(```|~~~)/.test(line)) fenced = !fenced;
+      if (!fenced && line.startsWith(marker) && current.length) {
+        parts.push(current.join("\n"));
+        current = [];
+      }
+      current.push(line);
+    }
+    if (current.length) parts.push(current.join("\n"));
+    return parts;
+  };
+
+  // Blank-line blocks, as a last resort when headings do not divide a section
+  // finely enough. `settings.md` is why this exists: one of its twelve `## `
+  // sections is 239KB with four `### ` inside it, so heading splits alone left
+  // a slice eight times over budget. Fences are tracked here too -- cutting a
+  // code block in half would hand the model a document it cannot reason about.
+  const cutBlocks = (body) => {
+    const blocks = [];
+    let current = [];
+    let fenced = false;
+    for (const line of body.split("\n")) {
+      if (/^\s*(```|~~~)/.test(line)) fenced = !fenced;
+      if (!fenced && line.trim() === "" && current.length) {
+        blocks.push(current.join("\n"));
+        current = [];
+      }
+      current.push(line);
+    }
+    if (current.length) blocks.push(current.join("\n"));
+    return blocks;
+  };
+
+  // Line packing, when even blank lines do not divide a block. Every remaining
+  // over-budget block measured was a long markdown table -- rows carry no
+  // blank line between them, so a 48KB table is one "block". A fence is never
+  // broken: if one is open, lines keep accumulating until it closes, so an
+  // oversized code block stays whole (it needs no translation anyway).
+  const cutLines = (body) => {
+    const out = [];
+    let current = [];
+    let size = 0;
+    let fenced = false;
+    for (const line of body.split("\n")) {
+      const isFence = /^\s*(```|~~~)/.test(line);
+      if (!fenced && !isFence && size && size + line.length + 1 > budget) {
+        out.push(current.join("\n"));
+        current = [];
+        size = 0;
+      }
+      if (isFence) fenced = !fenced;
+      current.push(line);
+      size += line.length + 1;
+    }
+    if (current.length) out.push(current.join("\n"));
+    return out;
+  };
+
+  const pieces = [];
+  const push = (piece, depth) => {
+    if (Buffer.byteLength(piece) <= budget || depth > 2) {
+      pieces.push(piece);
+      return;
+    }
+    const next =
+      depth === 0
+        ? cut(piece, "### ")
+        : depth === 1
+          ? cutBlocks(piece)
+          : cutLines(piece);
+    if (next.length < 2) {
+      push(piece, depth + 1);
+      return;
+    }
+    for (const part of next) push(part, depth + 1);
+  };
+  for (const section of cut(text, "## ")) push(section, 0);
+
+  const slices = [];
+  for (const piece of pieces) {
+    const last = slices[slices.length - 1];
+    if (last && Buffer.byteLength(last + "\n" + piece) <= budget)
+      slices[slices.length - 1] = last + "\n" + piece;
+    else slices.push(piece);
+  }
+  return slices.length ? slices : [text];
+}
+
+function renderPrompt(lang, batch, slice) {
   const tpl = fs.readFileSync(
     path.join(HERE, "prompts", "translate.md"),
     "utf8"
@@ -452,7 +571,11 @@ function renderPrompt(lang, batch) {
     const target = path.join(OPTS.contentDir, lang, rel);
     return {
       path: rel,
-      source: fs.readFileSync(path.join(OPTS.contentDir, "en", rel), "utf8"),
+      // A slice replaces the source with the part being worked on. The target
+      // stays whole, because that is what the replacements have to anchor in.
+      source: slice
+        ? slice.text
+        : fs.readFileSync(path.join(OPTS.contentDir, "en", rel), "utf8"),
       target: fs.existsSync(target) ? fs.readFileSync(target, "utf8") : null
     };
   });
@@ -465,6 +588,14 @@ function renderPrompt(lang, batch) {
     .replaceAll(
       "{{STYLE}}",
       fs.readFileSync(path.join(HERE, "STYLE.md"), "utf8")
+    )
+    .replaceAll(
+      "{{SCOPE}}",
+      slice
+        ? `This request covers part ${slice.index} of ${slice.total} of the source document. ` +
+          `The \`source\` below is only that part; \`target\` is the whole current translation. ` +
+          `Return replacements that bring the target in line with this part alone, and leave the rest of the target untouched.`
+        : ""
     )
     .replaceAll("{{DOCUMENTS}}", JSON.stringify(documents));
   return { documents, prompt };
@@ -798,6 +929,57 @@ async function cmdTranslate(lang) {
         (chunks.length > 1 ? ` (part ${part}/${chunks.length})` : "") +
         `: ${chunk.map((c) => relInContent(c.file)).join(", ")}...`
     );
+    // Large sources are worked one slice at a time. Slices are independent:
+    // one failing does not abandon the rest, because a partially updated page
+    // is closer to correct than the fully stale one it replaces, and anything
+    // structurally broken is caught by verify and restored by quarantine.
+    const enPath = path.join(OPTS.contentDir, "en", relInContent(chunk[0].file));
+    const targetPath = path.join(
+      OPTS.contentDir,
+      lang,
+      relInContent(chunk[0].file)
+    );
+    const source = fs.existsSync(enPath) ? fs.readFileSync(enPath, "utf8") : "";
+    const slices =
+      chunk.length === 1 &&
+      fs.existsSync(targetPath) &&
+      Buffer.byteLength(source) > SECTION_SPLIT_BYTES
+        ? splitSections(source)
+        : [null];
+    if (slices.length > 1)
+      console.log(
+        `[orch] ${lang}: source is ${Math.round(
+          Buffer.byteLength(source) / 1024
+        )}KB, translating in ${slices.length} slices`
+      );
+    let failedSlices = 0;
+    for (let sliceIndex = 0; sliceIndex < slices.length; sliceIndex++) {
+      const slice =
+        slices[sliceIndex] === null
+          ? undefined
+          : {
+              text: slices[sliceIndex],
+              index: sliceIndex + 1,
+              total: slices.length
+            };
+      const sliceSuffix = slice ? `${suffix}-slice${slice.index}` : suffix;
+      const outcome = await translateOnce(lang, chunk, slice, sliceSuffix);
+      if (outcome !== 0) failedSlices++;
+    }
+    if (failedSlices) {
+      console.log(
+        `::warning::${lang}: ${failedSlices}/${slices.length} slice(s) failed on part ${part}/${chunks.length}; its files stay in the backlog`
+      );
+      process.exitCode = 1;
+    }
+  }
+}
+
+/**
+ * One dispatch of one chunk (optionally one slice of it), with the retry #217
+ * added. Returns the agent's exit status.
+ */
+async function translateOnce(lang, chunk, slice, suffix) {
     let status;
     let log;
     for (let attempt = 1; attempt <= TRANSLATE_ATTEMPTS; attempt++) {
@@ -807,11 +989,12 @@ async function cmdTranslate(lang) {
       // failure.
       ({ status, log } = await runAgent(
         lang,
-        renderPrompt(lang, chunk),
+        renderPrompt(lang, chunk, slice),
         attempt === 1 ? suffix : `${suffix}-retry${attempt - 1}`
       ));
       console.log(
         `[orch] ${lang}: agent exit=${status}` +
+          (slice ? ` (slice ${slice.index}/${slice.total})` : "") +
           (attempt > 1 ? ` on retry ${attempt - 1}` : "") +
           ` (log: ${log})`
       );
@@ -821,21 +1004,10 @@ async function cmdTranslate(lang) {
         // attempt already translated. That redundancy is what keeps this
         // simple, and with one file per session it is cheap; verify's "touched
         // this session" check is satisfied by the rewrite either way.
-        console.log(
-          `[orch] ${lang}: part ${part}/${chunks.length} failed; retrying once...`
-        );
+        console.log(`[orch] ${lang}: ${suffix || "part"} failed; retrying once...`);
       }
     }
-    if (status !== 0) {
-      // The workflow's `|| true` keeps the step alive; surface the failure
-      // in the run summary anyway, and leave the chunk's files in the
-      // backlog (verify fails them; they are retried next run).
-      console.log(
-        `::warning::${lang}: agent exited ${status} on part ${part}/${chunks.length} after ${TRANSLATE_ATTEMPTS} attempts; its files stay in the backlog`
-      );
-      process.exitCode = 1;
-    }
-  }
+    return status;
 }
 
 // ---------- structural gate ----------

--- a/translator/orchestrator/prompts/translate.md
+++ b/translator/orchestrator/prompts/translate.md
@@ -24,5 +24,7 @@ Trusted glossary:
 Trusted style reference:
 {{STYLE}}
 
+{{SCOPE}}
+
 Untrusted documents encoded as JSON (`target` is null when missing):
 {{DOCUMENTS}}


### PR DESCRIPTION
Four documents fail every night, in every language, and can never advance. This is the change that unblocks them.

## The wall

In run [34462813835](https://github.com/QwenLM/qwen-code-docs/actions/runs/34462813835), **45 of 53 failures were a truncated JSON response** — and four documents accounted for 26 of them:

| Document | English source | Truncation failures |
| --- | --- | --- |
| `users/configuration/settings.md` | 324 KB | 7 (all seven locales) |
| `users/configuration/model-providers.md` | 59 KB | 7 |
| `users/qwen-serve.md` | 180 KB | 7 |
| `developers/daemon/02-serve-runtime.md` | 46 KB | 5 |

The model has to emit the translated text of everything it changes. For a 324KB source that response reached 90–177KB and was cut mid-string, so `parseStructuredResult` threw and the document's entire translation was discarded. Every night. This is not #269's problem — the patches never arrive to be matched.

## The change

Sources over **40KB** are translated one slice at a time. The threshold is measured: in that run every source above 47KB was truncated and every one at 29KB or below succeeded, so 40KB sits in the gap.

**Only the prompt's `source` is sliced.** `target` stays whole, so replacements still anchor in the complete document and `applyTranslationPatches` is untouched — no change to the write path at all. The prompt gains a scope line naming which part of N this request covers.

Slices are independent. One failing does not abandon the rest: a partially updated page is closer to correct than the stale one it replaces, and anything structurally broken is still caught by verify and restored by quarantine.

## Splitting needed four levels, not one

Headings alone are not enough. One of `settings.md`'s twelve `## ` sections is **239 KB** with four `### ` inside it, so heading splits left a slice eight times over budget:

| Fallback | Max slice on `settings.md` |
| --- | --- |
| `## ` only | 239 KB |
| `+ ### ` | 239 KB |
| `+ blank-line blocks` | 48 KB |
| `+ line packing` | **29 KB** |

The blank-line level was still not enough because the remaining oversized blocks are long markdown tables — rows carry no blank line between them, so a 48KB table is one "block". Line packing handles those, and **fences are tracked at every level**: if a code block is open, lines keep accumulating until it closes, so no slice ever opens a fence it does not close. An oversized code block stays whole, which is correct — it needs no translation.

## Verification

Over **all 178 English documents**:

- slices rejoin to the source **byte-for-byte** — 178 / 178
- **no slice exceeds** the 30KB budget — 0 over
- **no slice has unbalanced fences** — 0 unbalanced

The nine existing orchestrator tests still pass. There is no unit test for `splitSections` itself: it is not exported, and the existing tests drive the CLI. Rather than restructure the module for a seam, the 178-document sweep is the evidence.

## What this costs, honestly

Dispatches rise sharply for the affected files. One language's current ten-file backlog:

```
 1 dispatch          users/features/channels/dingtalk.md
 3 dispatches (sliced)  users/features/hooks.md
 9 dispatches (sliced)  users/qwen-serve.md
 1 dispatch          developers/contributing.md
 3 dispatches (sliced)  developers/daemon/02-serve-runtime.md
 4 dispatches (sliced)  developers/daemon/17-configuration.md
 4 dispatches (sliced)  developers/daemon/20-quickstart-operations.md
13 dispatches (sliced)  developers/qwen-serve-protocol.md
 3 dispatches (sliced)  users/configuration/model-providers.md
15 dispatches (sliced)  users/configuration/settings.md
```

**56 dispatches where there are now 10.** Runs will get longer. The 360-minute timeout is the guard, and `TRANSLATE_DAILY_LIMIT` is the lever if that is not enough. The trade is deliberate: those files currently cost a dispatch each *and produce nothing*, forever.

<details>
<summary>中文</summary>

有四篇文档每晚、每个语言都失败,且永远无法推进。本 PR 解开的就是它们。

**这堵墙**:在运行 34462813835 中,**53 次失败里有 45 次是 JSON 响应被截断**,而四篇文档就占了其中 26 次(见上表)。模型必须输出它所改动内容的全部译文,对 324KB 的源文件而言,该响应达到 90–177KB 并在字符串中途被切断,于是 `parseStructuredResult` 抛错、整篇文档的翻译被丢弃。每晚如此。这不是 #269 要解决的问题 —— 补丁根本没能送达匹配环节。

**改动**:源文件超过 **40KB** 时逐片翻译。阈值是实测的:该次运行中所有大于 47KB 的源都被截断,所有小于等于 29KB 的都成功,40KB 正落在空隙中。**只有提示词里的 `source` 被切片**,`target` 保持完整,因此补丁仍锚定在完整文档中,`applyTranslationPatches` 完全未动 —— 写入路径零改动。切片彼此独立:一片失败不会放弃其余,因为部分更新的页面比它所替代的陈旧页面更接近正确,而结构损坏的内容仍会被 verify 拦下、由 quarantine 恢复。

**切分需要四级兜底而非一级**:仅靠标题不够 —— `settings.md` 十二个 `## ` 节中有一节达 **239KB**、内含四个 `### `,标题切分后仍留下超预算八倍的切片(逐级效果见上表)。空行级仍不够,因为剩余超大块是长 markdown 表格 —— 表格行之间没有空行,所以 48KB 的表格就是一个"块"。行级打包解决了它,并且**每一级都跟踪围栏**:若代码块处于打开状态,行会持续累积直到闭合,因此任何切片都不会打开一个自己不闭合的围栏。超大代码块保持完整,这是正确的 —— 它本就不需要翻译。

**验证**:对**全部 178 篇英文文档**:切片可**逐字节**重组回原文(178/178);**无切片超过** 30KB 预算(0 个);**无切片围栏不闭合**(0 个)。现有九个 orchestrator 测试仍全部通过。`splitSections` 本身没有单元测试:它未导出,而现有测试是驱动 CLI 的;与其为一个测试缝重构模块,不如以这次 178 篇文档的全量扫描为证据。

**代价,如实说明**:受影响文件的派发次数大幅上升 —— 单语言当前十个文件的 backlog 将从 10 次派发变为 **56 次**。运行会变长,360 分钟超时是兜底,`TRANSLATE_DAILY_LIMIT` 是不够时的调节杆。这个取舍是刻意的:那些文件如今同样各消耗一次派发,**却什么都产出不了,而且永远如此**。

</details>

Ref #260.

https://claude.ai/code/session_01Sa8YZQrbc74Rdsfbhibkjy
