### PR TITLE
fix(nav): drop a ko key with no page, and catch the class in CI

### DIFF
--- a/.github/scripts/check-nav-keys.mjs
+++ b/.github/scripts/check-nav-keys.mjs
@@ -33,10 +33,27 @@ for (const lang of langs) {
     console.log(`${lang}: cannot be loaded — ${err.message}`);
     continue;
   }
-  const missing = en.filter((k) => !keys.includes(k));
+  const dir = `${process.cwd()}/content/${lang}/${file}`.replace(/\/[^/]+$/, "");
+  const hasPage = (k) =>
+    fs.existsSync(`${dir}/${k}`) ||
+    fs.existsSync(`${dir}/${k}.md`) ||
+    fs.existsSync(`${dir}/${k}.mdx`);
+  // An English key whose page this locale does not have yet is *correctly*
+  // absent from its `_meta`, so it is not a gap. Listing it would be the bug.
+  const missing = en.filter((k) => !keys.includes(k) && hasPage(k));
   const extra = keys.filter((k) => !en.includes(k));
   if (missing.length || extra.length)
     console.log(
       `${lang}: missing [${missing.join(", ")}] unexpected [${extra.join(", ")}]`
     );
+  // Matching English is not enough. A locale regenerated from English lists
+  // every English key, including pages that locale has not been translated
+  // yet -- and Nextra refuses to build a `_meta` key with no page behind it,
+  // taking the whole site down. That is what `ko` did: its file was created
+  // from nothing, listed `extensions`, and the deploy of 2026-09-11 failed
+  // with "refers to a page that cannot be found" while the key check said
+  // everything matched.
+  const orphans = keys.filter((k) => !hasPage(k));
+  if (orphans.length)
+    console.log(`${lang}: keys with no page [${orphans.join(", ")}]`);
 }

--- a/website/content/ko/developers/_meta.ts
+++ b/website/content/ko/developers/_meta.ts
@@ -25,7 +25,6 @@ export default {
   daemon: '데몬 모드 (개발자 심화)',
   'daemon-client-adapters': '데몬 클라이언트 어댑터',
   'daemon-ui': '데몬 UI',
-  extensions: '확장 프로그램',
   development: '개발',
 
   examples: '예제',


### PR DESCRIPTION
**The site has not deployed since 02:16.** The build of the #275/#276 merges failed and GitHub Pages is still serving the previous version.

```
Error: Validation of "_meta" file has failed.
The field key "extensions" in `_meta` file refers to a page that cannot be found,
remove this key from "_meta" file.
Error occurred prerendering page "/ko"
```

## One key, whole site

`ko/developers/_meta.ts` was created from nothing by #275 and listed every English key — `extensions` among them. But `website/content/ko/developers/extensions/` does not exist: those pages are not translated yet. Nextra refuses to build a `_meta` key with no page behind it.

`ko` is the only locale affected. The other seven have the directory, which is why this shipped unnoticed.

## The guard passed it, and was right to

The route-key check compared ko's keys against English and found them identical — exactly what it was asked to do. **Matching English is not sufficient for a locale that is missing pages**, and for a file generated from English it is precisely the wrong thing to require.

Two changes to `check-nav-keys.mjs`:

- it now reports **keys with no page behind them**, which is the build-breaking class
- it no longer reports an English key as "missing" when that locale has **no page** for it — listing it would be the bug, not the fix

## Verification

Silent on the fixed tree. Putting `extensions` back reproduces it:

```
ko: keys with no page [extensions]
```

Swept every `_meta.ts` in the repository against all seven locales: **no other orphan key exists**, so this is the only thing standing between `main` and a green deploy.

The sweep did surface something else, which is *not* a build problem and not in scope here: several `_meta.ts` files omit pages the locale already has — `users/features/_meta.ts` omits 14 of them in six locales. Those pages still render, auto-appended with filename-derived titles, which is the same drift #263 fixed for `developers/`. Worth its own pass.

<details>
<summary>中文</summary>

**站点自 02:16 起未再部署** —— #275/#276 合并后的构建失败,GitHub Pages 仍在提供上一版本。

**一个 key 拖垮整站**:`ko/developers/_meta.ts` 由 #275 从零生成,照英文列出了所有 key,其中包括 `extensions`;但 `website/content/ko/developers/extensions/` 并不存在 —— 那批页面尚未翻译成韩语。Nextra 拒绝构建没有对应页面的 `_meta` key。八个语言中只有 `ko` 受影响,其余七个都有该目录,这正是它悄无声息上线的原因。

**护栏放行了它,而且按其自身定义是正确的**:路由 key 检查比对 ko 与英文,发现完全一致 —— 这正是它被要求做的事。**对一个缺页面的语言而言,"与英文一致"并不充分**;而对一个从英文生成的文件来说,要求这一点恰恰是错的。`check-nav-keys.mjs` 两处改动:现在会报告**没有对应页面的 key**(这才是会导致构建失败的那一类);不再把某英文 key 报为"缺失" —— 当该语言根本没有对应页面时,列出它才是 bug。

**验证**:修复后的代码树上检查静默;把 `extensions` 放回去即复现 `ko: keys with no page [extensions]`。已对仓库中全部 `_meta.ts` × 七个语言做了扫描:**不存在其他孤儿 key**,所以这是 `main` 与绿色部署之间唯一的阻碍。

扫描另外发现一件事,不属构建问题也不在本 PR 范围:若干 `_meta.ts` 遗漏了该语言已经拥有的页面 —— `users/features/_meta.ts` 在六个语言中各遗漏 14 个。那些页面仍会渲染,只是被自动追加并使用文件名生成的标题,与 #263 为 `developers/` 修复的是同一类漂移,值得单独处理一次。

</details>

https://claude.ai/code/session_01Sa8YZQrbc74Rdsfbhibkjy