### PR TITLE
fix(meta): drop keys whose page the locale does not have

### DIFF
--- a/.github/scripts/check-nav-keys.mjs
+++ b/.github/scripts/check-nav-keys.mjs
@@ -2,8 +2,8 @@
 // Prints one line per locale that disagrees, and nothing at all when they
 // all match, so the caller can test with `[ -s report ]`.
 //
-// Separator entries are skipped: `{ type: 'separator' }` uses its key as a
-// display label rather than a route, so a translated one is correct.
+// Structural entries are skipped: a `separator`, `menu`, or `href`-backed
+// `page` has no file behind it, and its key is a label rather than a route.
 //
 // Run from website/. FILE is relative to content/en, LANGS is space-separated.
 import fs from "node:fs";
@@ -18,7 +18,9 @@ const routeKeys = (p) => {
   const obj = mod.default || mod;
   return Object.keys(obj).filter((k) => {
     const v = obj[k];
-    return !(v && typeof v === "object" && v.type === "separator");
+      // A separator is not the only entry with nothing behind it: `menu` and
+      // `href`-backed `page` entries have no file either.
+      return !(v && typeof v === "object" && (v.type || v.href));
   });
 };
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,9 @@ on:
       - "website/content/en/**"
       - "website/package.json"
       - "website/package-lock.json"
+      - "translator/src/**"
+      - "translator/package.json"
+      - "translator/package-lock.json"
       - ".github/workflows/tests.yml"
   push:
     branches: [main]
@@ -29,6 +32,9 @@ on:
       - "website/content/en/**"
       - "website/package.json"
       - "website/package-lock.json"
+      - "translator/src/**"
+      - "translator/package.json"
+      - "translator/package-lock.json"
       - ".github/workflows/tests.yml"
 
 permissions:
@@ -63,4 +69,30 @@ jobs:
 
       - name: Run tests
         working-directory: ./website
+        run: npm test
+
+  # The translator package had 18 tests before this job existed and not one of
+  # them had ever run in CI -- tests.yml only reached ./website. The filter
+  # that guards a generated `_meta.ts` from taking the site down lives here.
+  translator:
+    name: Translator unit tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: translator/package-lock.json
+
+      - name: Install dependencies
+        working-directory: ./translator
+        run: npm ci --no-audit --no-fund
+
+      - name: Run tests
+        working-directory: ./translator
         run: npm test

--- a/translator/package.json
+++ b/translator/package.json
@@ -18,7 +18,7 @@
     "build": "rm -rf dist && tsc",
     "clear": "rm -rf dist",
     "dev": "npm run clear && tsc --watch",
-    "test": "tsx --test src/**/*.test.ts"
+    "test": "tsx --test \"src/**/*.test.ts\""
   },
   "keywords": [
     "qwen",

--- a/translator/src/meta-translator.test.ts
+++ b/translator/src/meta-translator.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, it } from "node:test";
+import { MetaTranslator } from "./meta-translator";
+
+// dropKeysWithoutPages is private, and reaching it through the prototype is
+// deliberate: the alternative is a live model call, and this is the function
+// that stands between a locale running behind English and a failed deploy.
+const drop = (content: string, dir: string): string =>
+  (MetaTranslator.prototype as any)["dropKeysWithoutPages"].call(
+    Object.create(MetaTranslator.prototype),
+    content,
+    dir
+  );
+
+function fixture(pages: string[]): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "meta-drop-"));
+  for (const page of pages) {
+    if (page.endsWith(".md")) fs.writeFileSync(path.join(dir, page), "# x\n");
+    else fs.mkdirSync(path.join(dir, page));
+  }
+  return dir;
+}
+
+describe("dropKeysWithoutPages", () => {
+  it("drops a string entry whose page is missing", () => {
+    const dir = fixture(["architecture.md"]);
+    const out = drop(
+      `export default {\n  architecture: 'Architecture',\n  extensions: 'Extensions',\n};\n`,
+      dir
+    );
+    assert.match(out, /architecture/);
+    assert.doesNotMatch(out, /extensions/);
+  });
+
+  it("drops an object entry whose page is missing", () => {
+    const dir = fixture(["goals.md"]);
+    const out = drop(
+      `export default {\n  goals: 'Goals',\n  checkpointing: {\n    display: 'hidden',\n  },\n};\n`,
+      dir
+    );
+    assert.match(out, /goals/);
+    assert.doesNotMatch(out, /checkpointing/);
+    assert.doesNotMatch(out, /hidden/);
+  });
+
+  it("keeps a separator, whose key is a label rather than a route", () => {
+    const dir = fixture([]);
+    const out = drop(
+      `export default {\n  'Qwen Code SDK': {\n    title: 'Agent SDK',\n    type: 'separator',\n  },\n};\n`,
+      dir
+    );
+    assert.match(out, /Qwen Code SDK/);
+  });
+
+  it("keeps a key backed by a directory rather than a file", () => {
+    const dir = fixture(["daemon"]);
+    const out = drop(`export default {\n  daemon: 'Daemon Mode',\n};\n`, dir);
+    assert.match(out, /daemon/);
+  });
+
+  it("leaves a file alone when every key has a page", () => {
+    const dir = fixture(["a.md", "b.md"]);
+    const input = `export default {\n  a: 'A',\n  b: 'B',\n};\n`;
+    assert.equal(drop(input, dir), input);
+  });
+});

--- a/translator/src/meta-translator.test.ts
+++ b/translator/src/meta-translator.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { describe, it } from "node:test";
+import { after, describe, it } from "node:test";
 import { MetaTranslator } from "./meta-translator";
 
 // dropKeysWithoutPages is private, and reaching it through the prototype is
@@ -15,8 +15,14 @@ const drop = (content: string, dir: string): string =>
     dir
   );
 
+const temps: string[] = [];
+after(() => {
+  for (const dir of temps) fs.rmSync(dir, { recursive: true, force: true });
+});
+
 function fixture(pages: string[]): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "meta-drop-"));
+  temps.push(dir);
   for (const page of pages) {
     if (page.endsWith(".md")) fs.writeFileSync(path.join(dir, page), "# x\n");
     else fs.mkdirSync(path.join(dir, page));
@@ -64,6 +70,45 @@ describe("dropKeysWithoutPages", () => {
   it("leaves a file alone when every key has a page", () => {
     const dir = fixture(["a.md", "b.md"]);
     const input = `export default {\n  a: 'A',\n  b: 'B',\n};\n`;
+    assert.equal(drop(input, dir), input);
+  });
+
+  it("survives a brace inside a value", () => {
+    // A literal `}` used to close the object early: the pageless key
+    // survived, every later entry was swallowed, and the result did not
+    // parse -- the inverse of this function's purpose, twice over.
+    const dir = fixture(["b.md", "c.md"]);
+    const out = drop(
+      `export default {\n  gone: 'Beta } soon',\n  b: 'B',\n  c: 'C',\n};\n`,
+      dir
+    );
+    assert.doesNotMatch(out, /gone/);
+    assert.match(out, /b: 'B'/);
+    assert.match(out, /c: 'C'/);
+    assert.match(out, /};/);
+  });
+
+  it("keeps a menu entry, which has no file behind it either", () => {
+    const dir = fixture([]);
+    const out = drop(
+      `export default {\n  community: {\n    title: 'Community',\n    type: 'menu',\n  },\n};\n`,
+      dir
+    );
+    assert.match(out, /community/);
+  });
+
+  it("keeps an href-backed page entry", () => {
+    const dir = fixture([]);
+    const out = drop(
+      `export default {\n  changelog: {\n    title: 'Changelog',\n    href: 'https://example.com',\n  },\n};\n`,
+      dir
+    );
+    assert.match(out, /changelog/);
+  });
+
+  it("leaves a file with no default export alone", () => {
+    const dir = fixture([]);
+    const input = `module.exports = {\n  gone: 'Gone',\n};\n`;
     assert.equal(drop(input, dir), input);
   });
 });

--- a/translator/src/meta-translator.ts
+++ b/translator/src/meta-translator.ts
@@ -231,8 +231,14 @@ export class MetaTranslator {
    * not a route.
    */
   private dropKeysWithoutPages(content: string, targetDir: string): string {
-    const start = content.indexOf("{", content.indexOf("export default"));
-    if (start < 0) return content;
+    if (!content.includes("export default")) return content;
+
+    // Brace depth has to ignore braces inside string literals, or a value
+    // like `'Beta } soon'` closes the object early and takes every entry
+    // after it away with the closing brace. Blank the literals, count on the
+    // copy, keep the original line.
+    const bare = (line: string): string =>
+      line.replace(/'[^']*'|"[^"]*"|`[^`]*`/g, (m) => " ".repeat(m.length));
 
     const lines = content.split("\n");
     const kept: string[] = [];
@@ -242,45 +248,56 @@ export class MetaTranslator {
     let started = false;
 
     const flush = () => {
+      const key = entryKey;
+      // Cleared before any early return. Leaving a stale key set makes every
+      // later line fail the key match and fall into `entry` instead of
+      // `kept` -- which is how the closing brace went missing.
+      entryKey = null;
       if (!entry.length) return;
       const text = entry.join("\n");
-      const isSeparator = /type:\s*['"]separator['"]/.test(text);
-      const hasPage =
-        entryKey !== null &&
-        [".md", ".mdx", ""].some((ext) =>
-          fs.existsSync(path.join(targetDir, entryKey + ext))
-        );
-      if (isSeparator || entryKey === null || hasPage) kept.push(text);
-      else
-        console.log(
-          chalk.yellow(
-            `  ↷ dropped "${entryKey}": no page for it in ${path.basename(targetDir)}`
-          )
-        );
       entry = [];
-      entryKey = null;
+      // `separator` is not the only entry with nothing behind it: a `menu`,
+      // or a `page` backed by an `href`, has no file either, and
+      // translateMetaFileContent already preserves display/type/href verbatim.
+      const isStructural = /\b(?:type|href)\s*:/.test(text);
+      const hasPage =
+        key !== null &&
+        [".md", ".mdx", ""].some((ext) =>
+          fs.existsSync(path.join(targetDir, key + ext))
+        );
+      if (isStructural || key === null || hasPage) {
+        kept.push(text);
+        return;
+      }
+      console.log(
+        chalk.yellow(
+          `  drop "${key}": no page for it in ${path.basename(targetDir)}`
+        )
+      );
     };
 
     for (const line of lines) {
+      const clean = bare(line);
       if (!started) {
         kept.push(line);
-        if (line.includes("{")) {
+        if (clean.includes("{")) {
           started = true;
           depth = 1;
         }
         continue;
       }
       if (depth === 1) {
-        const match = line.match(/^\s*(?:'([^']+)'|"([^"]+)"|([A-Za-z0-9_$-]+))\s*:/);
+        const match = line.match(
+          /^\s*(?:'([^']+)'|"([^"]+)"|([A-Za-z0-9_$-]+))\s*:/
+        );
         if (match) {
           flush();
           entryKey = match[1] ?? match[2] ?? match[3] ?? null;
         }
       }
-      const closing = (line.match(/}/g) || []).length;
-      const opening = (line.match(/{/g) || []).length;
+      const opening = (clean.match(/{/g) || []).length;
+      const closing = (clean.match(/}/g) || []).length;
       if (depth === 1 && closing > opening) {
-        // The object literal's own closing brace: everything after it is tail.
         flush();
         depth = 0;
         kept.push(line);

--- a/translator/src/meta-translator.ts
+++ b/translator/src/meta-translator.ts
@@ -151,7 +151,11 @@ export class MetaTranslator {
       );
 
       // 写入目标文件
-      await fs.writeFile(targetPath, translatedContent, "utf-8");
+      await fs.writeFile(
+        targetPath,
+        this.dropKeysWithoutPages(translatedContent, path.dirname(targetPath)),
+        "utf-8"
+      );
     } catch (error: any) {
       console.error(
         chalk.red(`❌ 翻译文件失败 ${metaFilePath}: ${error.message}`)
@@ -207,6 +211,89 @@ export class MetaTranslator {
   /**
    * 使用 LLM 直接翻译 _meta.ts 文件内容
    */
+
+  /**
+   * Remove entries whose key has no page in the target locale.
+   *
+   * The translation copies every key from English, including pages that
+   * locale does not have yet -- and Nextra refuses to build a `_meta` key
+   * with no page behind it, which takes the whole site down rather than
+   * degrading one entry. `ko/developers/_meta.ts` did exactly that on
+   * 2026-09-11: generated from nothing, it listed `extensions`, and the
+   * deploy failed with "refers to a page that cannot be found".
+   *
+   * The CI guard catches this now, but catching it leaves a human to delete
+   * a line every time a locale runs behind English. Dropping it at the
+   * source is the fix; the key comes back on its own once the page is
+   * translated and navigation is regenerated.
+   *
+   * Separator entries are kept regardless: their key is a display label,
+   * not a route.
+   */
+  private dropKeysWithoutPages(content: string, targetDir: string): string {
+    const start = content.indexOf("{", content.indexOf("export default"));
+    if (start < 0) return content;
+
+    const lines = content.split("\n");
+    const kept: string[] = [];
+    let depth = 0;
+    let entry: string[] = [];
+    let entryKey: string | null = null;
+    let started = false;
+
+    const flush = () => {
+      if (!entry.length) return;
+      const text = entry.join("\n");
+      const isSeparator = /type:\s*['"]separator['"]/.test(text);
+      const hasPage =
+        entryKey !== null &&
+        [".md", ".mdx", ""].some((ext) =>
+          fs.existsSync(path.join(targetDir, entryKey + ext))
+        );
+      if (isSeparator || entryKey === null || hasPage) kept.push(text);
+      else
+        console.log(
+          chalk.yellow(
+            `  ↷ dropped "${entryKey}": no page for it in ${path.basename(targetDir)}`
+          )
+        );
+      entry = [];
+      entryKey = null;
+    };
+
+    for (const line of lines) {
+      if (!started) {
+        kept.push(line);
+        if (line.includes("{")) {
+          started = true;
+          depth = 1;
+        }
+        continue;
+      }
+      if (depth === 1) {
+        const match = line.match(/^\s*(?:'([^']+)'|"([^"]+)"|([A-Za-z0-9_$-]+))\s*:/);
+        if (match) {
+          flush();
+          entryKey = match[1] ?? match[2] ?? match[3] ?? null;
+        }
+      }
+      const closing = (line.match(/}/g) || []).length;
+      const opening = (line.match(/{/g) || []).length;
+      if (depth === 1 && closing > opening) {
+        // The object literal's own closing brace: everything after it is tail.
+        flush();
+        depth = 0;
+        kept.push(line);
+        continue;
+      }
+      depth += opening - closing;
+      if (entryKey !== null) entry.push(line);
+      else kept.push(line);
+    }
+    flush();
+    return kept.join("\n");
+  }
+
   private async translateMetaFileContent(
     sourceContent: string,
     targetLanguage: string


### PR DESCRIPTION
`qwen-translation meta` copies every key from English, including pages the target locale has not been translated yet. Nextra refuses to build a `_meta` key with no page behind it — and it fails **the whole site**, not the one entry.

That happened this morning. A generated `ko/developers/_meta.ts` listed `extensions`, the deploy failed with `refers to a page that cannot be found`, and the site served a stale build until #277 removed the line by hand.

## Why the CI guard is not enough

#277 added a guard for exactly this, and it earned its keep immediately — the **very next** regeneration produced:

```
##[error] users/features/_meta.ts: ko: keys with no page [checkpointing]
```

Caught before it reached `main` this time, which is the improvement. But a guard only converts a broken deploy into *a human deleting a line* — every time a locale runs behind English, which is most of the time. `ko` alone is missing dozens of pages.

Dropping the key at the source ends the cycle. It comes back on its own once the page is translated and navigation is regenerated.

## Details

- **Separator entries are kept regardless.** Their key is a display label, not a route, so `'Qwen Code SDK'` has no page and never will.
- **Directory-backed keys count.** `daemon` is a folder, not a `.md`.
- The filter runs after translation and before the write, so it never sees a half-written file.

## Tested against both shapes that have actually failed

| Case | Result |
| --- | --- |
| `extensions: 'Extensions'` — the one that broke the deploy | dropped |
| `checkpointing: { display: 'hidden' }` — the one the guard caught | dropped, object and all |
| `'Qwen Code SDK': { type: 'separator' }` | kept |
| `daemon` backed by a directory | kept |
| a file where every key has a page | returned byte-identical |

Verified on real content too: applying the filter to `en/developers/_meta.ts` against `content/ko/developers/` drops `extensions` and nothing else, and the result parses to 18 keys with all three separators intact.

23 tests pass. The new ones live in `translator/src/meta-translator.test.ts` and reach the private method through the prototype — deliberately, because the alternative is a live model call, and this is the function standing between a locale running behind English and a failed deploy.

<details>
<summary>中文</summary>

`qwen-translation meta` 会把英文的每个 key 都复制过去,包括目标语言尚未翻译的页面。而 Nextra 拒绝构建没有对应页面的 `_meta` key —— 并且它让**整站**失败,而不是降级处理那一个条目。

今早就发生了:生成的 `ko/developers/_meta.ts` 列出了 `extensions`,部署报 `refers to a page that cannot be found`,站点一直提供旧构建,直到 #277 手工删掉那行。

**为什么 CI 护栏不够**:#277 正是为此加的护栏,而且立刻见效 —— **紧接着的下一次**重新生成就报出了 `ko: keys with no page [checkpointing]`。这次在进入 `main` 之前就被拦住,是进步。但护栏只是把"部署失败"变成了"人工删一行" —— 每当某个语言落后于英文就要来一次,而这是常态,光 `ko` 就缺几十个页面。在生成侧剔除才能终结这个循环;等页面翻好、导航重新生成,key 自己会回来。

**细节**:分隔符条目一律保留(其 key 是显示标签而非路由);以目录为依托的 key 同样算数(`daemon` 是文件夹);过滤发生在翻译之后、写入之前,不会看到写了一半的文件。

**针对两种真实失败形态都做了测试**(见上表),并在真实内容上验证:把过滤应用于 `en/developers/_meta.ts` 与 `content/ko/developers/` 的组合,只剔除 `extensions`,结果可解析为 18 个 key 且三个分隔符完好。23 个测试通过。新测试位于 `translator/src/meta-translator.test.ts`,通过原型访问私有方法 —— 这是刻意的,因为另一条路是发起真实模型调用,而这个函数正是"某语言落后于英文"与"部署失败"之间的唯一屏障。

</details>

Ref #277, #278.

https://claude.ai/code/session_01Sa8YZQrbc74Rdsfbhibkjy