### PR TITLE
feat(meta): translate only the keys a locale is missing

### DIFF
--- a/translator/src/meta-translator.test.ts
+++ b/translator/src/meta-translator.test.ts
@@ -15,6 +15,26 @@ const drop = (content: string, dir: string): string =>
     dir
   );
 
+function tree(spec: {
+  en: string;
+  zh?: string;
+  pages: string[];
+}): { dir: string; meta: any } {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "meta-add-"));
+  temps.push(dir);
+  for (const lang of ["en", "zh", "ko"]) fs.mkdirSync(path.join(dir, lang));
+  fs.writeFileSync(path.join(dir, "en", "_meta.ts"), spec.en);
+  if (spec.zh) fs.writeFileSync(path.join(dir, "zh", "_meta.ts"), spec.zh);
+  for (const lang of ["zh", "ko"])
+    for (const page of spec.pages)
+      fs.writeFileSync(path.join(dir, lang, page), "# x\n");
+  const meta: any = Object.create(MetaTranslator.prototype);
+  meta.projectRoot = dir;
+  meta.outputDir = ".";
+  meta.sourceLanguage = "en";
+  return { dir, meta };
+}
+
 const temps: string[] = [];
 after(() => {
   for (const dir of temps) fs.rmSync(dir, { recursive: true, force: true });
@@ -110,5 +130,59 @@ describe("dropKeysWithoutPages", () => {
     const dir = fixture([]);
     const input = `module.exports = {\n  gone: 'Gone',\n};\n`;
     assert.equal(drop(input, dir), input);
+  });
+
+  it("keeps the file byte-identical when nothing is missing", async () => {
+    const { dir, meta } = tree({
+      en: `export default {\n  a: 'A',\n  b: 'B',\n};\n`,
+      zh: `export default {\n  a: '甲',\n  b: '乙',\n};\n`,
+      pages: ["a.md", "b.md"]
+    });
+    let called = false;
+    meta.translateMetaFileContent = async () => {
+      called = true;
+      return "";
+    };
+    await meta.translateMetaFile("_meta.ts", "zh");
+    assert.equal(called, false, "should not call the model at all");
+    assert.equal(
+      fs.readFileSync(path.join(dir, "zh", "_meta.ts"), "utf8"),
+      `export default {\n  a: '甲',\n  b: '乙',\n};\n`
+    );
+  });
+
+  it("translates only the missing keys and preserves the rest", async () => {
+    const { dir, meta } = tree({
+      en: `export default {\n  a: 'A',\n  c: 'C',\n  b: 'B',\n};\n`,
+      zh: `export default {\n  a: '甲',\n  b: '乙',\n};\n`,
+      pages: ["a.md", "b.md", "c.md"]
+    });
+    let seen = "";
+    meta.translateMetaFileContent = async (partial: string) => {
+      seen = partial;
+      return `export default {\n  c: '丙',\n};\n`;
+    };
+    await meta.translateMetaFile("_meta.ts", "zh");
+    // Only the missing key reaches the model.
+    assert.match(seen, /c: 'C'/);
+    assert.doesNotMatch(seen, /a: 'A'/);
+    assert.doesNotMatch(seen, /b: 'B'/);
+    // Existing values survive, and English order decides placement.
+    const out = fs.readFileSync(path.join(dir, "zh", "_meta.ts"), "utf8");
+    assert.equal(out, `export default {\n  a: '甲',\n  c: '丙',\n  b: '乙',\n};\n`);
+  });
+
+  it("translates everything when the target does not exist", async () => {
+    const { dir, meta } = tree({
+      en: `export default {\n  a: 'A',\n};\n`,
+      pages: ["a.md"]
+    });
+    meta.translateMetaFileContent = async () =>
+      `export default {\n  a: '甲',\n};\n`;
+    await meta.translateMetaFile("_meta.ts", "ko");
+    assert.match(
+      fs.readFileSync(path.join(dir, "ko", "_meta.ts"), "utf8"),
+      /a: '甲'/
+    );
   });
 });

--- a/translator/src/meta-translator.ts
+++ b/translator/src/meta-translator.ts
@@ -141,21 +141,56 @@ export class MetaTranslator {
     await fs.ensureDir(path.dirname(targetPath));
 
     try {
-      // 读取源文件内容
       const sourceContent = await fs.readFile(sourcePath, "utf-8");
+      const source = this.parseEntries(sourceContent);
+      const existing = (await fs.pathExists(targetPath))
+        ? this.parseEntries(await fs.readFile(targetPath, "utf-8"))
+        : null;
 
-      // 直接使用 LLM 翻译整个文件内容
-      const translatedContent = await this.translateMetaFileContent(
-        sourceContent,
-        targetLanguage
+      // Additive. Re-translating a key that already has a value rewrites a
+      // human-reviewed string for no reason, and the rewrite drifts toward
+      // English: one regeneration turned de `Fähigkeiten` into `Skills`, ja
+      // `LSP（言語サーバープロトコル）` into `LSP (Language Server Protocol)`,
+      // and zh `频道` into `通道` -- a mistranslation, in a section about
+      // Telegram and WeChat. 33 values were rewritten that way in a single
+      // run and had to be restored by hand (#278). Only what is missing is
+      // sent to the model.
+      const have = new Set((existing?.entries ?? []).map(([key]) => key));
+      const missing = source.entries.filter(([key]) => !have.has(key));
+
+      if (existing && !missing.length) {
+        console.log(chalk.gray(`  = ${targetLanguage}: already complete`));
+        return;
+      }
+
+      const partial = [
+        ...source.head,
+        ...missing.map(([, text]) => text),
+        ...source.tail
+      ].join("\n");
+      const translated = this.parseEntries(
+        await this.translateMetaFileContent(partial, targetLanguage)
       );
+      const fresh = new Map(translated.entries);
+      const kept = new Map(existing?.entries ?? []);
 
-      // 写入目标文件
+      // English order, existing values preserved, new values filled in.
+      const merged = source.entries
+        .map(([key]) => kept.get(key) ?? fresh.get(key))
+        .filter((text): text is string => text !== undefined);
+
       await fs.writeFile(
         targetPath,
-        this.dropKeysWithoutPages(translatedContent, path.dirname(targetPath)),
+        this.dropKeysWithoutPages(
+          [...source.head, ...merged, ...source.tail].join("\n"),
+          path.dirname(targetPath)
+        ),
         "utf-8"
       );
+      if (existing)
+        console.log(
+          chalk.gray(`  + ${targetLanguage}: ${missing.length} new key(s)`)
+        );
     } catch (error: any) {
       console.error(
         chalk.red(`❌ 翻译文件失败 ${metaFilePath}: ${error.message}`)
@@ -230,6 +265,78 @@ export class MetaTranslator {
    * Separator entries are kept regardless: their key is a display label,
    * not a route.
    */
+
+  /**
+   * Split a `_meta.ts` into its preamble, one text block per top-level entry,
+   * and its tail, preserving the original formatting of every block.
+   *
+   * Shares its brace handling with dropKeysWithoutPages: string literals are
+   * blanked before counting, because a value carrying a `}` would otherwise
+   * close the object early.
+   */
+  private parseEntries(content: string): {
+    head: string[];
+    entries: Array<[string, string]>;
+    tail: string[];
+  } {
+    const bare = (line: string): string =>
+      line.replace(/'[^']*'|"[^"]*"|`[^`]*`/g, (m) => " ".repeat(m.length));
+
+    const head: string[] = [];
+    const tail: string[] = [];
+    const entries: Array<[string, string]> = [];
+    let current: string[] = [];
+    let key: string | null = null;
+    let depth = 0;
+    let started = false;
+
+    const flush = () => {
+      const k = key;
+      key = null;
+      if (!current.length || k === null) {
+        current = [];
+        return;
+      }
+      entries.push([k, current.join("\n")]);
+      current = [];
+    };
+
+    for (const line of content.split("\n")) {
+      const clean = bare(line);
+      if (!started) {
+        head.push(line);
+        if (clean.includes("{")) {
+          started = true;
+          depth = 1;
+        }
+        continue;
+      }
+      if (depth === 1) {
+        const match = line.match(
+          /^\s*(?:'([^']+)'|"([^"]+)"|([A-Za-z0-9_$-]+))\s*:/
+        );
+        if (match) {
+          flush();
+          key = match[1] ?? match[2] ?? match[3] ?? null;
+        }
+      }
+      const opening = (clean.match(/{/g) || []).length;
+      const closing = (clean.match(/}/g) || []).length;
+      if (depth === 1 && closing > opening) {
+        flush();
+        depth = 0;
+        tail.push(line);
+        continue;
+      }
+      depth += opening - closing;
+      if (key !== null) current.push(line);
+      else if (depth === 0) tail.push(line);
+      else head.push(line);
+    }
+    flush();
+    return { head, entries, tail };
+  }
+
   private dropKeysWithoutPages(content: string, targetDir: string): string {
     if (!content.includes("export default")) return content;
 


### PR DESCRIPTION
Every regeneration re-translated **every** value, and the rewrites drifted toward English:

| locale | key | was | regenerated as |
| --- | --- | --- | --- |
| de | `skills` | `Fähigkeiten` | `Skills` |
| ja | `lsp` | `LSP（言語サーバープロトコル）` | `LSP (Language Server Protocol)` |
| pt-BR | `skills` | `Habilidades` | `Skills` |
| zh | `channels` | `频道` | `通道` |

That last one is not a stylistic difference — the section is Telegram / WeChat / DingTalk, and `通道` reads as a conduit. One run rewrote **33 human-reviewed values** that did not need to change, and restoring them by hand was most of the work on #278. The three PRs open right now (#280, #281, #282) each carry the same churn.

## The change

The command is additive:

- keys the target already has **keep their text untouched**
- only what is missing is sent to the model
- the result is assembled in **English's key order**, so new entries land in their curated position rather than at the end
- a target that is already complete is **skipped entirely, with no model call**

That last point is not just tidiness. Running this against the current tree, `zh/users/features/_meta.ts` is missing 0 keys — so today it would cost 7 model calls to rewrite 7 files into something worse, and now it costs none.

This is the same argument #279 makes: **do not convert a generator problem into a human editing problem.** #279 stopped it emitting keys with no page behind them; this stops it rewriting values nobody asked it to touch.

## Verification

`parseEntries` shares its brace handling with `dropKeysWithoutPages` — string literals are blanked before counting, so a value carrying a `}` cannot close the object early. It **round-trips all 128 `_meta.ts` files in the repository byte-for-byte**.

30 tests, three of them new:

| case | asserts |
| --- | --- |
| nothing missing | the model is never called, and the file is byte-identical |
| two keys missing | only those two reach the model; existing values survive; English order decides placement |
| no target file | the locale still gets everything |

## Follow-up

#280, #281 and #282 were generated before this. They can either be regenerated once this lands — which will produce a clean additive diff — or have their values restored the way #278 did. Regenerating is cheaper now that a complete file costs nothing.

<details>
<summary>中文</summary>

每次重新生成都会重译**所有**值,而且译文向英文漂移(见上表)。其中 `zh` 的 `channels` 由 `频道` 变为 `通道` 并非风格差异 —— 该章节讲的是 Telegram / 微信 / 钉钉,而 `通道` 读作管道。一次运行改写了 **33 个经人工审阅过的值**,而把它们还原回去构成了 #278 的主要工作量。当前开着的三个 PR(#280、#281、#282)各自带着同样的噪音。

**改动**:命令改为增量式 —— 目标已有的 key **原文保留**;只把缺失的部分送给模型;结果按**英文的 key 顺序**组装,使新条目落在编排位置而非末尾;目标若已完整则**整体跳过,零模型调用**。最后一点不只是整洁:对当前代码树运行,`zh/users/features/_meta.ts` 缺 0 个 key —— 也就是说今天它会花 7 次模型调用把 7 个文件改得更糟,而现在一次都不花。

这与 #279 是同一个论点:**不要把生成器的问题转化为人工编辑的问题。** #279 阻止它产出没有页面的 key,本 PR 阻止它改写没人要求它碰的值。

**验证**:`parseEntries` 与 `dropKeysWithoutPages` 共用大括号处理 —— 计数前先把字符串字面量挖空,因此含 `}` 的值无法提前闭合对象。它对仓库中全部 **128 个 `_meta.ts` 文件逐字节无损往返**。30 个测试,其中三个是新增(见上表)。

**后续**:#280、#281、#282 生成于本 PR 之前,可在本 PR 合入后重新生成(将得到干净的增量 diff),或按 #278 的方式还原其值。鉴于完整文件如今零成本,重新生成更划算。

</details>

Ref #278, #279.

https://claude.ai/code/session_01Sa8YZQrbc74Rdsfbhibkjy