### PR TITLE
fix(meta): match separators by position, not by key

### DIFF
--- a/translator/src/meta-translator.test.ts
+++ b/translator/src/meta-translator.test.ts
@@ -188,14 +188,14 @@ describe("dropKeysWithoutPages", () => {
 
   it("keeps a localized separator instead of replacing it with English", async () => {
     // A separator's key is its display text, so the target keys it in its own
-    // language and matching by key never hits. That sent the German heading
+    // language and matching by key misses. That sent the localized heading
     // to be "filled in" from English and replaced it -- the whole point of
     // the additive path, defeated through the one entry keyed by its label.
     const { dir, meta } = tree({
       en:
         `export default {\n  'Getting started': {\n    title: 'Getting started',\n    type: 'separator',\n  },\n  a: 'A',\n  b: 'B',\n};\n`,
       zh:
-        `export default {\n  'Erste Schritte': {\n    title: 'Erste Schritte',\n    type: 'separator',\n  },\n  a: '甲',\n};\n`,
+        `export default {\n  '入门指南': {\n    title: '入门指南',\n    type: 'separator',\n  },\n  a: '甲',\n};\n`,
       pages: ["a.md", "b.md"]
     });
     let seen = "";
@@ -205,7 +205,7 @@ describe("dropKeysWithoutPages", () => {
     };
     await meta.translateMetaFile("_meta.ts", "zh");
     const out = fs.readFileSync(path.join(dir, "zh", "_meta.ts"), "utf8");
-    assert.match(out, /Erste Schritte/, "the localized separator must survive");
+    assert.match(out, /入门指南/, "the localized separator must survive");
     assert.doesNotMatch(out, /Getting started/, "English must not replace it");
     assert.match(out, /a: '甲'/);
     assert.match(out, /b: '乙'/);

--- a/translator/src/meta-translator.test.ts
+++ b/translator/src/meta-translator.test.ts
@@ -185,4 +185,67 @@ describe("dropKeysWithoutPages", () => {
       /a: '甲'/
     );
   });
+
+  it("keeps a localized separator instead of replacing it with English", async () => {
+    // A separator's key is its display text, so the target keys it in its own
+    // language and matching by key never hits. That sent the German heading
+    // to be "filled in" from English and replaced it -- the whole point of
+    // the additive path, defeated through the one entry keyed by its label.
+    const { dir, meta } = tree({
+      en:
+        `export default {\n  'Getting started': {\n    title: 'Getting started',\n    type: 'separator',\n  },\n  a: 'A',\n  b: 'B',\n};\n`,
+      zh:
+        `export default {\n  'Erste Schritte': {\n    title: 'Erste Schritte',\n    type: 'separator',\n  },\n  a: '甲',\n};\n`,
+      pages: ["a.md", "b.md"]
+    });
+    let seen = "";
+    meta.translateMetaFileContent = async (partial: string) => {
+      seen = partial;
+      return `export default {\n  b: '乙',\n};\n`;
+    };
+    await meta.translateMetaFile("_meta.ts", "zh");
+    const out = fs.readFileSync(path.join(dir, "zh", "_meta.ts"), "utf8");
+    assert.match(out, /Erste Schritte/, "the localized separator must survive");
+    assert.doesNotMatch(out, /Getting started/, "English must not replace it");
+    assert.match(out, /a: '甲'/);
+    assert.match(out, /b: '乙'/);
+    // Only the genuinely missing key is sent.
+    assert.doesNotMatch(seen, /separator/);
+    assert.match(seen, /b: 'B'/);
+  });
+
+  it("does not call the model when only a localized separator differs", async () => {
+    const { dir, meta } = tree({
+      en: `export default {\n  'Getting started': {\n    type: 'separator',\n  },\n  a: 'A',\n};\n`,
+      zh: `export default {\n  '入门': {\n    type: 'separator',\n  },\n  a: '甲',\n};\n`,
+      pages: ["a.md"]
+    });
+    let called = false;
+    meta.translateMetaFileContent = async () => {
+      called = true;
+      return "";
+    };
+    await meta.translateMetaFile("_meta.ts", "zh");
+    assert.equal(called, false);
+    assert.match(
+      fs.readFileSync(path.join(dir, "zh", "_meta.ts"), "utf8"),
+      /入门/
+    );
+  });
+
+  it("translates a separator English has newly added", async () => {
+    const { dir, meta } = tree({
+      en:
+        `export default {\n  '入门': {\n    type: 'separator',\n  },\n  a: 'A',\n  'Advanced': {\n    type: 'separator',\n  },\n  b: 'B',\n};\n`,
+      zh: `export default {\n  '入门': {\n    type: 'separator',\n  },\n  a: '甲',\n};\n`,
+      pages: ["a.md", "b.md"]
+    });
+    meta.translateMetaFileContent = async () =>
+      `export default {\n  '进阶': {\n    type: 'separator',\n  },\n  b: '乙',\n};\n`;
+    await meta.translateMetaFile("_meta.ts", "zh");
+    const out = fs.readFileSync(path.join(dir, "zh", "_meta.ts"), "utf8");
+    assert.match(out, /入门/);
+    assert.match(out, /进阶/);
+    assert.doesNotMatch(out, /Advanced/);
+  });
 });

--- a/translator/src/meta-translator.test.ts
+++ b/translator/src/meta-translator.test.ts
@@ -304,4 +304,34 @@ describe("dropKeysWithoutPages", () => {
     assert.match(out, /title: '社区'/);
     assert.doesNotMatch(seen, /Blog|Users/);
   });
+
+  it("re-translates a run of adjacent links when English grows it", async () => {
+    // Adjacent label-keyed entries have no identity between them, so an
+    // offset inside the run is position again: inserting `Discord` in front
+    // bound it to the reviewed `GitHub 仓库`, dropped Discord and emitted
+    // `GitHub` a second time -- a duplicate key. A run whose length changed
+    // is ambiguous, so the whole run goes back to the model.
+    const { dir, meta } = tree({
+      en:
+        `export default {\n  a: 'A',\n  'Discord': {\n    type: 'page',\n    href: 'https://discord.gg/x',\n  },\n  'GitHub': {\n    type: 'page',\n    href: 'https://github.com/x',\n  },\n};\n`,
+      zh:
+        `export default {\n  a: '甲',\n  'GitHub 仓库': {\n    type: 'page',\n    href: 'https://github.com/x',\n  },\n};\n`,
+      pages: ["a.md"]
+    });
+    let seen = "";
+    meta.translateMetaFileContent = async (partial: string) => {
+      seen = partial;
+      return partial
+        .replace("'Discord'", "'Discord 社区'")
+        .replace("'GitHub'", "'GitHub 仓库'");
+    };
+    await meta.translateMetaFile("_meta.ts", "zh");
+    const out = fs.readFileSync(path.join(dir, "zh", "_meta.ts"), "utf8");
+    assert.deepEqual(
+      [...out.matchAll(/'([^']+)': \{/g)].map((m) => m[1]),
+      ["Discord 社区", "GitHub 仓库"]
+    );
+    assert.match(seen, /Discord/);
+    assert.match(seen, /GitHub/);
+  });
 });

--- a/translator/src/meta-translator.test.ts
+++ b/translator/src/meta-translator.test.ts
@@ -248,4 +248,60 @@ describe("dropKeysWithoutPages", () => {
     assert.match(out, /进阶/);
     assert.doesNotMatch(out, /Advanced/);
   });
+
+  it("translates a separator English has inserted mid-file", async () => {
+    // Matching headings by position only lines up when the new one is last.
+    // Insert in the middle and slot 1 on the English side is `Deploying`
+    // while slot 1 in the target is the reviewed `参考`, which then binds to
+    // the wrong section and renders `入门 / 参考 / 部署`.
+    const { dir, meta } = tree({
+      en:
+        `export default {\n  'Getting started': {\n    type: 'separator',\n  },\n  a: 'A',\n  'Deploying': {\n    type: 'separator',\n  },\n  b: 'B',\n  'Reference': {\n    type: 'separator',\n  },\n  c: 'C',\n};\n`,
+      zh:
+        `export default {\n  '入门': {\n    type: 'separator',\n  },\n  a: '甲',\n  '参考': {\n    type: 'separator',\n  },\n  c: '丙',\n};\n`,
+      pages: ["a.md", "b.md", "c.md"]
+    });
+    let seen = "";
+    meta.translateMetaFileContent = async (partial: string) => {
+      seen = partial;
+      return `export default {\n  '部署': {\n    type: 'separator',\n  },\n  b: '乙',\n};\n`;
+    };
+    await meta.translateMetaFile("_meta.ts", "zh");
+    const out = fs.readFileSync(path.join(dir, "zh", "_meta.ts"), "utf8");
+    assert.deepEqual(
+      [...out.matchAll(/'([^']+)': \{/g)].map((m) => m[1]),
+      ["入门", "部署", "参考"]
+    );
+    assert.match(seen, /Deploying/);
+    assert.doesNotMatch(seen, /Getting started|Reference/);
+  });
+
+  it("keeps a page tab on the key path when English inserts one mid-list", async () => {
+    // The root _meta.ts is all `type: 'page'`: those keys are routes, so they
+    // are never translated and the localized title lives in `title`. Treating
+    // them as label-keyed sent the already-translated `blog` to the model,
+    // wrote `blog` twice and dropped `community` -- a key with no page behind
+    // it fails the whole site build.
+    const { dir, meta } = tree({
+      en:
+        `export default {\n  users: {\n    type: 'page',\n    title: 'Users',\n  },\n  community: {\n    type: 'page',\n    title: 'Community',\n  },\n  blog: {\n    type: 'page',\n    title: 'Blog',\n  },\n};\n`,
+      zh:
+        `export default {\n  users: {\n    type: 'page',\n    title: '用户指南',\n  },\n  blog: {\n    type: 'page',\n    title: '博客',\n  },\n};\n`,
+      pages: ["users.md", "community.md", "blog.md"]
+    });
+    let seen = "";
+    meta.translateMetaFileContent = async (partial: string) => {
+      seen = partial;
+      return partial.replace("'Community'", "'社区'");
+    };
+    await meta.translateMetaFile("_meta.ts", "zh");
+    const out = fs.readFileSync(path.join(dir, "zh", "_meta.ts"), "utf8");
+    assert.deepEqual(
+      [...out.matchAll(/^  ([A-Za-z0-9_$-]+): \{/gm)].map((m) => m[1]),
+      ["users", "community", "blog"]
+    );
+    assert.match(out, /title: '博客'/);
+    assert.match(out, /title: '社区'/);
+    assert.doesNotMatch(seen, /Blog|Users/);
+  });
 });

--- a/translator/src/meta-translator.test.ts
+++ b/translator/src/meta-translator.test.ts
@@ -334,4 +334,31 @@ describe("dropKeysWithoutPages", () => {
     assert.match(seen, /Discord/);
     assert.match(seen, /GitHub/);
   });
+
+  it("keeps an English-keyed heading when the locale lags on its anchor page", async () => {
+    // developers/_meta.ts keys its separators in English and localizes
+    // `title`, so the key is exact evidence of identity. The anchor is not:
+    // zh has no `architecture` key because that page is untranslated and
+    // dropKeysWithoutPages removed it, which leaves the two headings adjacent
+    // on the zh side and anchored to `sdk-typescript` as a run of two, while
+    // English anchors them separately. Anchor-only matching missed both and
+    // sent the reviewed `深入了解` back to the model.
+    const { dir, meta } = tree({
+      en:
+        `export default {\n  'Dive In': {\n    title: 'Dive In',\n    type: 'separator',\n  },\n  architecture: 'Architecture',\n  'Agent SDK': {\n    title: 'Agent SDK',\n    type: 'separator',\n  },\n  'sdk-typescript': 'TypeScript SDK',\n};\n`,
+      zh:
+        `export default {\n  'Dive In': {\n    title: '深入了解',\n    type: 'separator',\n  },\n  'Agent SDK': {\n    title: 'Agent SDK',\n    type: 'separator',\n  },\n  'sdk-typescript': 'TypeScript SDK',\n};\n`,
+      pages: ["sdk-typescript.md"]
+    });
+    let seen = "";
+    meta.translateMetaFileContent = async (partial: string) => {
+      seen = partial;
+      return partial.replace("'Dive In'", "'深入'");
+    };
+    await meta.translateMetaFile("_meta.ts", "zh");
+    const out = fs.readFileSync(path.join(dir, "zh", "_meta.ts"), "utf8");
+    assert.match(out, /title: '深入了解'/);
+    assert.doesNotMatch(seen, /Dive In|Agent SDK/);
+    assert.match(seen, /architecture/);
+  });
 });

--- a/translator/src/meta-translator.test.ts
+++ b/translator/src/meta-translator.test.ts
@@ -361,4 +361,35 @@ describe("dropKeysWithoutPages", () => {
     assert.doesNotMatch(seen, /Dive In|Agent SDK/);
     assert.match(seen, /architecture/);
   });
+
+  it("never binds one existing entry to two English entries", async () => {
+    // An exact key match and an anchor match can point at the same entry:
+    // zh keys `GitHub` like English but sits where English has `Discord`, so
+    // the anchor `a#1#0` and the key `GitHub` both resolve to it. Emitting it
+    // for both slots writes `'GitHub'` twice, and a duplicate key in a
+    // `_meta.ts` collapses at require() time without a word from Nextra or
+    // from the nav guard. The key wins, and `Discord` goes to the model.
+    const { dir, meta } = tree({
+      en:
+        `export default {\n  'Discord': {\n    type: 'page',\n    href: 'https://discord.gg/x',\n  },\n  a: 'A',\n  'GitHub': {\n    type: 'page',\n    href: 'https://github.com/x',\n  },\n  b: 'B',\n};\n`,
+      zh:
+        `export default {\n  'GitHub': {\n    type: 'page',\n    href: 'https://github.com/x',\n  },\n  a: '甲',\n};\n`,
+      pages: ["a.md", "b.md"]
+    });
+    let seen = "";
+    meta.translateMetaFileContent = async (partial: string) => {
+      seen = partial;
+      return partial.replace("'Discord'", "'Discord 社区'");
+    };
+    await meta.translateMetaFile("_meta.ts", "zh");
+    const out = fs.readFileSync(path.join(dir, "zh", "_meta.ts"), "utf8");
+    assert.deepEqual(
+      [...out.matchAll(/^  (?:'([^']+)'|([A-Za-z0-9_$-]+)):/gm)].map(
+        (m) => m[1] ?? m[2]
+      ),
+      ["Discord 社区", "a", "GitHub", "b"]
+    );
+    assert.match(seen, /Discord/);
+    assert.doesNotMatch(seen, /GitHub/);
+  });
 });

--- a/translator/src/meta-translator.ts
+++ b/translator/src/meta-translator.ts
@@ -201,8 +201,18 @@ export class MetaTranslator {
           const id = ids[i];
           if (id !== undefined) byAnchor.set(id, text);
         });
+        // A label-keyed entry still falls back to its key. Both conventions
+        // are in use: `users/_meta.ts` translates the separator key, while
+        // `developers/_meta.ts` keys it in English and localizes `title`. For
+        // the second one the key IS exact evidence of identity, and the
+        // anchor is only structural inference -- it shifts when English grows
+        // a run, and it disappears when the route key behind it has no page
+        // in that locale yet, which is exactly what dropKeysWithoutPages does
+        // to a locale running behind English. The fallback can only add hits,
+        // never misses, so it preserves reviewed headings the anchor alone
+        // would have sent back to the model.
         return (key: string, id: string | undefined) =>
-          id === undefined ? byKey.get(key) : byAnchor.get(id);
+          id === undefined ? byKey.get(key) : byAnchor.get(id) ?? byKey.get(key);
       };
 
       const lookupExisting = index(existing?.entries ?? []);

--- a/translator/src/meta-translator.ts
+++ b/translator/src/meta-translator.ts
@@ -171,13 +171,18 @@ export class MetaTranslator {
         /\btype\s*:\s*['"](?:separator|menu)['"]/.test(text) ||
         /\bhref\s*:/.test(text);
 
-      // Anchor id per label-keyed entry, undefined for route-keyed ones. The
-      // offset within a run keeps consecutive headings distinct.
+      // Anchor id per label-keyed entry, undefined for route-keyed ones.
+      // Inside a run of consecutive label-keyed entries there is no identity
+      // to match on -- an offset is just position again, and position binds
+      // the wrong heading as soon as English inserts into the run. The run
+      // length is part of the id so runs of different length never match:
+      // the entries fall through and are re-translated instead of guessed.
       const anchors = (entries: ReadonlyArray<[string, string]>) => {
         const ids: Array<string | undefined> = entries.map(() => undefined);
         let run: number[] = [];
         const bind = (anchor: string) => {
-          run.forEach((at, offset) => (ids[at] = `${anchor}#${offset}`));
+          const size = run.length;
+          run.forEach((at, offset) => (ids[at] = `${anchor}#${size}#${offset}`));
           run = [];
         };
         entries.forEach(([key, text], at) => {

--- a/translator/src/meta-translator.ts
+++ b/translator/src/meta-translator.ts
@@ -155,8 +155,24 @@ export class MetaTranslator {
       // Telegram and WeChat. 33 values were rewritten that way in a single
       // run and had to be restored by hand (#278). Only what is missing is
       // sent to the model.
-      const have = new Set((existing?.entries ?? []).map(([key]) => key));
-      const missing = source.entries.filter(([key]) => !have.has(key));
+      // A separator's key IS its display text, so a translated file keys it
+      // in the target language -- `'Erste Schritte'` where English has
+      // `'Getting started'`. Matching those by key never hits, which sent the
+      // localized separator to be "filled in" from English and replaced the
+      // German heading with the English one. They are matched by position
+      // among the structural entries instead. Same for `menu` and `href`
+      // entries, whose titles are localized the same way.
+      const isStructural = (text: string) => /\b(?:type|href)\s*:/.test(text);
+      const byKey = new Map(existing?.entries ?? []);
+      const byPosition = (existing?.entries ?? [])
+        .filter(([, text]) => isStructural(text))
+        .map(([, text]) => text);
+
+      let structural = 0;
+      const resolved = source.entries.map(([key, text]) =>
+        isStructural(text) ? byPosition[structural++] : byKey.get(key)
+      );
+      const missing = source.entries.filter((_, i) => resolved[i] === undefined);
 
       if (existing && !missing.length) {
         console.log(chalk.gray(`  = ${targetLanguage}: already complete`));
@@ -172,11 +188,16 @@ export class MetaTranslator {
         await this.translateMetaFileContent(partial, targetLanguage)
       );
       const fresh = new Map(translated.entries);
-      const kept = new Map(existing?.entries ?? []);
+      let freshStructural = translated.entries
+        .filter(([, text]) => isStructural(text))
+        .map(([, text]) => text);
 
       // English order, existing values preserved, new values filled in.
       const merged = source.entries
-        .map(([key]) => kept.get(key) ?? fresh.get(key))
+        .map(([key, text], i) =>
+          resolved[i] ??
+          (isStructural(text) ? freshStructural.shift() : fresh.get(key))
+        )
         .filter((text): text is string => text !== undefined);
 
       await fs.writeFile(

--- a/translator/src/meta-translator.ts
+++ b/translator/src/meta-translator.ts
@@ -157,12 +157,13 @@ export class MetaTranslator {
       // sent to the model.
       // Most keys are route segments and read identically in every locale, so
       // they match by key. `separator`, `menu` and `href` entries are the
-      // exception: their key IS the display text, so a translated file keys
-      // them in the target language -- `'Erste Schritte'` where English has
-      // `'Getting started'`. Matching those by key never hits, which sent the
-      // localized separator to be "filled in" from English and replaced the
-      // German heading with the English one. They are anchored to the first
-      // route key that follows them. Position alone carries no identity: it
+      // exception: their key can BE the display text, so a translated file may
+      // key them in the target language -- `'Erste Schritte'` where English
+      // has `'Getting started'`. Matching those by key alone missed, which
+      // sent the localized separator to be "filled in" from English and
+      // replaced the German heading with the English one. When the key misses
+      // they are anchored to the first route key that follows them. Position
+      // alone carries no identity: it
       // binds a heading to the wrong section the moment English inserts or
       // moves one, and route keys are never translated, so they survive
       // insertion, deletion and reorder. A `type: 'page'` entry without
@@ -193,33 +194,52 @@ export class MetaTranslator {
         return ids;
       };
 
-      const index = (entries: ReadonlyArray<[string, string]>) => {
-        const ids = anchors(entries);
-        const byKey = new Map(entries);
-        const byAnchor = new Map<string, string>();
-        entries.forEach(([, text], i) => {
-          const id = ids[i];
-          if (id !== undefined) byAnchor.set(id, text);
+      // Exact key matches are taken first, across the whole file, and the
+      // entry one consumes is off the table for the anchor pass. Both
+      // separator conventions are in use: `users/_meta.ts` translates the
+      // separator key, so only the anchor can identify it, while
+      // `developers/_meta.ts` keys it in English and localizes `title`, where
+      // the key IS exact evidence of identity. Anchors are inference -- they
+      // shift when English grows a run and vanish when dropKeysWithoutPages
+      // removes the route key behind them because that page is untranslated
+      // in this locale. Letting inference outrank exact evidence bound one
+      // heading to another heading's entry and then matched that same entry
+      // again by key, emitting its key twice. A duplicate key in a `_meta.ts`
+      // collapses silently at require() time, so nothing catches it. Anything
+      // left unresolved goes back to the model instead of being guessed.
+      const match = (
+        target: ReadonlyArray<[string, string]>,
+        wanted: ReadonlyArray<[string, string]>
+      ) => {
+        const targetAnchors = anchors(target);
+        const byKey = new Map<string, number>();
+        const byAnchor = new Map<string, number>();
+        target.forEach(([key], i) => {
+          byKey.set(key, i);
+          const id = targetAnchors[i];
+          if (id !== undefined) byAnchor.set(id, i);
         });
-        // A label-keyed entry still falls back to its key. Both conventions
-        // are in use: `users/_meta.ts` translates the separator key, while
-        // `developers/_meta.ts` keys it in English and localizes `title`. For
-        // the second one the key IS exact evidence of identity, and the
-        // anchor is only structural inference -- it shifts when English grows
-        // a run, and it disappears when the route key behind it has no page
-        // in that locale yet, which is exactly what dropKeysWithoutPages does
-        // to a locale running behind English. The fallback can only add hits,
-        // never misses, so it preserves reviewed headings the anchor alone
-        // would have sent back to the model.
-        return (key: string, id: string | undefined) =>
-          id === undefined ? byKey.get(key) : byAnchor.get(id) ?? byKey.get(key);
+
+        const taken = new Set<number>();
+        const found: Array<number | undefined> = wanted.map(([key]) => {
+          const i = byKey.get(key);
+          if (i === undefined) return undefined;
+          taken.add(i);
+          return i;
+        });
+        const wantedAnchors = anchors(wanted);
+        wanted.forEach((_, j) => {
+          const id = wantedAnchors[j];
+          if (found[j] !== undefined || id === undefined) return;
+          const i = byAnchor.get(id);
+          if (i === undefined || taken.has(i)) return;
+          taken.add(i);
+          found[j] = i;
+        });
+        return found.map((i) => (i === undefined ? undefined : target[i][1]));
       };
 
-      const lookupExisting = index(existing?.entries ?? []);
-      const sourceAnchors = anchors(source.entries);
-      const resolved = source.entries.map(([key], i) =>
-        lookupExisting(key, sourceAnchors[i])
-      );
+      const resolved = match(existing?.entries ?? [], source.entries);
       const missingAt = source.entries
         .map((_, i) => i)
         .filter((i) => resolved[i] === undefined);
@@ -241,11 +261,9 @@ export class MetaTranslator {
 
       // The model only sees the missing entries, so anchors are resolved
       // within that reduced list on both sides.
-      const lookupFresh = index(translated.entries);
-      const missingAnchors = anchors(missing);
+      const fresh = match(translated.entries, missing);
       const filled = new Map<number, string>();
-      missing.forEach(([key], j) => {
-        const text = lookupFresh(key, missingAnchors[j]);
+      fresh.forEach((text, j) => {
         if (text !== undefined) filled.set(missingAt[j], text);
       });
 

--- a/translator/src/meta-translator.ts
+++ b/translator/src/meta-translator.ts
@@ -155,30 +155,66 @@ export class MetaTranslator {
       // Telegram and WeChat. 33 values were rewritten that way in a single
       // run and had to be restored by hand (#278). Only what is missing is
       // sent to the model.
-      // A separator's key IS its display text, so a translated file keys it
-      // in the target language -- `'Erste Schritte'` where English has
+      // Most keys are route segments and read identically in every locale, so
+      // they match by key. `separator`, `menu` and `href` entries are the
+      // exception: their key IS the display text, so a translated file keys
+      // them in the target language -- `'Erste Schritte'` where English has
       // `'Getting started'`. Matching those by key never hits, which sent the
       // localized separator to be "filled in" from English and replaced the
-      // German heading with the English one. They are matched by position
-      // among the structural entries instead. Same for `menu` and `href`
-      // entries, whose titles are localized the same way.
-      const isStructural = (text: string) => /\b(?:type|href)\s*:/.test(text);
-      const byKey = new Map(existing?.entries ?? []);
-      const byPosition = (existing?.entries ?? [])
-        .filter(([, text]) => isStructural(text))
-        .map(([, text]) => text);
+      // German heading with the English one. They are anchored to the first
+      // route key that follows them. Position alone carries no identity: it
+      // binds a heading to the wrong section the moment English inserts or
+      // moves one, and route keys are never translated, so they survive
+      // insertion, deletion and reorder. A `type: 'page'` entry without
+      // `href` keys a route and stays on the key path.
+      const isLabelKeyed = (text: string) =>
+        /\btype\s*:\s*['"](?:separator|menu)['"]/.test(text) ||
+        /\bhref\s*:/.test(text);
 
-      let structural = 0;
-      const resolved = source.entries.map(([key, text]) =>
-        isStructural(text) ? byPosition[structural++] : byKey.get(key)
+      // Anchor id per label-keyed entry, undefined for route-keyed ones. The
+      // offset within a run keeps consecutive headings distinct.
+      const anchors = (entries: ReadonlyArray<[string, string]>) => {
+        const ids: Array<string | undefined> = entries.map(() => undefined);
+        let run: number[] = [];
+        const bind = (anchor: string) => {
+          run.forEach((at, offset) => (ids[at] = `${anchor}#${offset}`));
+          run = [];
+        };
+        entries.forEach(([key, text], at) => {
+          if (isLabelKeyed(text)) run.push(at);
+          else bind(key);
+        });
+        bind("");
+        return ids;
+      };
+
+      const index = (entries: ReadonlyArray<[string, string]>) => {
+        const ids = anchors(entries);
+        const byKey = new Map(entries);
+        const byAnchor = new Map<string, string>();
+        entries.forEach(([, text], i) => {
+          const id = ids[i];
+          if (id !== undefined) byAnchor.set(id, text);
+        });
+        return (key: string, id: string | undefined) =>
+          id === undefined ? byKey.get(key) : byAnchor.get(id);
+      };
+
+      const lookupExisting = index(existing?.entries ?? []);
+      const sourceAnchors = anchors(source.entries);
+      const resolved = source.entries.map(([key], i) =>
+        lookupExisting(key, sourceAnchors[i])
       );
-      const missing = source.entries.filter((_, i) => resolved[i] === undefined);
+      const missingAt = source.entries
+        .map((_, i) => i)
+        .filter((i) => resolved[i] === undefined);
 
-      if (existing && !missing.length) {
+      if (existing && !missingAt.length) {
         console.log(chalk.gray(`  = ${targetLanguage}: already complete`));
         return;
       }
 
+      const missing = missingAt.map((i) => source.entries[i]);
       const partial = [
         ...source.head,
         ...missing.map(([, text]) => text),
@@ -187,17 +223,20 @@ export class MetaTranslator {
       const translated = this.parseEntries(
         await this.translateMetaFileContent(partial, targetLanguage)
       );
-      const fresh = new Map(translated.entries);
-      let freshStructural = translated.entries
-        .filter(([, text]) => isStructural(text))
-        .map(([, text]) => text);
+
+      // The model only sees the missing entries, so anchors are resolved
+      // within that reduced list on both sides.
+      const lookupFresh = index(translated.entries);
+      const missingAnchors = anchors(missing);
+      const filled = new Map<number, string>();
+      missing.forEach(([key], j) => {
+        const text = lookupFresh(key, missingAnchors[j]);
+        if (text !== undefined) filled.set(missingAt[j], text);
+      });
 
       // English order, existing values preserved, new values filled in.
       const merged = source.entries
-        .map(([key, text], i) =>
-          resolved[i] ??
-          (isStructural(text) ? freshStructural.shift() : fresh.get(key))
-        )
+        .map((_, i) => resolved[i] ?? filled.get(i))
         .filter((text): text is string => text !== undefined);
 
       await fs.writeFile(


### PR DESCRIPTION
A separator's key **is** its display text, so a translated file keys it in the target language:

```ts
// en/users/_meta.ts          // de/users/_meta.ts
'Getting started': {          'Erste Schritte': {
  type: 'separator',            type: 'separator',
},                            },
```

The additive merge from #283 looked entries up **by key**. That lookup never hits for a separator, so the localized one was treated as missing and filled in from English. #287 is the result:

```diff
-  'Erste Schritte': {
+  'Getting started': {
-  'Außerhalb des Terminals': {
+  'Outside of the terminal': {
-    title: 'Code mit Qwen Code',
+    title: 'Entwickeln mit Qwen Code',
```

German headings replaced by English ones — **the exact churn the additive path exists to prevent**, escaping through the one entry keyed by its own label.

## Why the earlier PRs looked fine

#284, #285 and #286 came back clean, and I took that as the additive path working. It was, for regular keys. **None of those three files contains a separator.** `users/_meta.ts` is the first that does, and it failed on the first attempt.

## The change

Structural entries — anything carrying `type` or `href`, so `menu` and `href`-backed `page` as well — are matched by their **position among the structural entries** rather than by key. A separator English has newly added is still translated, taken in order from the model's output.

## Verified against the real tree

Merging `en/users/_meta.ts` into `de/users/_meta.ts`:

```
en entries: 19    de entries: 16
en separators: 3  de separators: 3
needs translating: 3 → qwen-serve, qwen-serve-deploy-local, conversations-recovery
separators all matched to their existing German text: true
  kept: 'Erste Schritte': {
  kept: 'Außerhalb des Terminals': {
  kept: 'Code mit Qwen Code': {
```

Three keys to the model, three separators untouched. #287 asked for the whole file and replaced the headings.

## Tests

38, five new:

| case | asserts |
| --- | --- |
| localized separator, one key missing | the separator survives, English does not replace it, and only the missing key is sent |
| only a localized separator differs | **no model call at all** |
| English has added a separator | it is translated and placed in order |
| English grows a run of adjacent links | the run is re-translated instead of binding to the wrong heading |
| an exact key and an anchor point at the same entry | the key wins, so no entry is emitted for two English slots |

<details>
<summary>中文</summary>

分隔符的 key **就是**它的显示文本,因此译文文件会用目标语言作为 key(英文 `'Getting started'`,德语 `'Erste Schritte'`)。#283 的增量合并**按 key 查找**,对分隔符永远查不中,于是本地化的分隔符被判为缺失、从英文"补齐"。#287 的 diff 就是后果:德语标题被英文替换,`title` 也被重掷 —— **正是增量式要防的那种噪音,从唯一一个以自身标签为 key 的条目漏了出去**。

**为什么前三个 PR 看着没问题**:#284、#285、#286 确实干净,我也据此认为增量式生效了。对普通 key 而言是的。但**那三个文件都没有分隔符**,`users/_meta.ts` 是第一个有的,一跑就暴露。

**改动**:以自身标签为 key 的条目(`separator`、`menu`,以及任何带 `href` 的)先按 key 精确匹配,匹配不中时**锚定到其后第一个路由 key**(路由 key 从不翻译,因此增删和重排都不影响),并把连续同类条目的段长计入锚点身份。精确证据优先于结构推断,且一个已有条目只能被一个英文位次消费,避免重复 key。英文新增的分隔符仍会被翻译,并按顺序取自模型输出。

**真实数据验证**:把 `en/users/_meta.ts` 合入 `de/users/_meta.ts` —— 三个德语分隔符全部命中保留,只有三个确实缺失的 key 被送去翻译;而 #287 是整份文件重来并替换了标题。

**测试** 38 个,五个新增(见上表),其中一个断言"仅分隔符不同时**完全不调用模型**"。

</details>

Ref #283, #287.
