### PR TITLE
fix(orchestrator): give preflight a retry window worth having

### DIFF
--- a/translator/orchestrator/orchestrator.mjs
+++ b/translator/orchestrator/orchestrator.mjs
@@ -1797,6 +1797,9 @@ function cmdReportBatch() {
  * fails fast.
  */
 const PREFLIGHT_ATTEMPTS = 5;
+// Overridable so the test for this does not have to sit through the real
+// backoff; nothing in CI or the workflow sets it.
+const PREFLIGHT_BACKOFF_MS = Number(process.env.PREFLIGHT_BACKOFF_MS) || 15_000;
 
 async function cmdPreflight() {
   const base = (
@@ -1849,7 +1852,10 @@ async function cmdPreflight() {
         console.log(`::error::preflight: ${err.message}${cause}`);
         process.exit(1);
       }
-      const wait = Math.min(120_000, 15_000 * 2 ** (attempt - 1));
+      const wait = Math.min(
+        8 * PREFLIGHT_BACKOFF_MS,
+        PREFLIGHT_BACKOFF_MS * 2 ** (attempt - 1)
+      );
       console.log(
         `::warning::preflight attempt ${attempt}/${PREFLIGHT_ATTEMPTS} failed: ${err.message}${cause}; retrying in ${wait / 1000}s...`
       );

--- a/translator/orchestrator/orchestrator.mjs
+++ b/translator/orchestrator/orchestrator.mjs
@@ -1796,6 +1796,8 @@ function cmdReportBatch() {
  * any non-2xx or network failure exits non-zero so the workflow step
  * fails fast.
  */
+const PREFLIGHT_ATTEMPTS = 5;
+
 async function cmdPreflight() {
   const base = (
     process.env.OPENAI_BASE_URL || "https://coding.dashscope.aliyuncs.com/v1"
@@ -1806,7 +1808,16 @@ async function cmdPreflight() {
     process.exit(1);
   }
   const model = OPTS.model || process.env.QWEN_MODEL || "qwen3.7-plus";
-  for (let attempt = 1; attempt <= 3; attempt++) {
+  // Five attempts over ~3.5 minutes, not three over three seconds.
+  //
+  // The old window was 1s + 2s, which only ever caught a single dropped
+  // packet. The endpoint this runs against blips for longer than that: the
+  // scheduled runs of 09-09 and 09-11 both died here inside a minute, and
+  // both succeeded on a rerun with nothing changed in between. A night of
+  // translation is worth several minutes of waiting, and when the endpoint
+  // really is down the job still fails -- just later, and having actually
+  // tried.
+  for (let attempt = 1; attempt <= PREFLIGHT_ATTEMPTS; attempt++) {
     try {
       const res = await fetch(`${base}/chat/completions`, {
         method: "POST",
@@ -1834,14 +1845,15 @@ async function cmdPreflight() {
       return;
     } catch (err) {
       const cause = err.cause?.code ? ` (${err.cause.code})` : "";
-      if (attempt === 3) {
+      if (attempt === PREFLIGHT_ATTEMPTS) {
         console.log(`::error::preflight: ${err.message}${cause}`);
         process.exit(1);
       }
+      const wait = Math.min(120_000, 15_000 * 2 ** (attempt - 1));
       console.log(
-        `::warning::preflight attempt ${attempt}/3 failed: ${err.message}${cause}; retrying...`
+        `::warning::preflight attempt ${attempt}/${PREFLIGHT_ATTEMPTS} failed: ${err.message}${cause}; retrying in ${wait / 1000}s...`
       );
-      await new Promise((resolve) => setTimeout(resolve, attempt * 1000));
+      await new Promise((resolve) => setTimeout(resolve, wait));
     }
   }
 }

--- a/translator/src/orchestrator-preflight.test.ts
+++ b/translator/src/orchestrator-preflight.test.ts
@@ -30,6 +30,9 @@ test("preflight retries a transient network failure", async () => {
           ...process.env,
           OPENAI_API_KEY: "test-key",
           OPENAI_BASE_URL: `http://127.0.0.1:${address.port}`,
+          // The real first backoff is 15s. The point here is that a retry
+          // happens at all, not how long it waits for.
+          PREFLIGHT_BACKOFF_MS: "10",
         },
       }
     );
@@ -42,7 +45,7 @@ test("preflight retries a transient network failure", async () => {
 
     assert.equal(status, 0, output);
     assert.equal(requests, 2);
-    assert.match(output, /attempt 1\/3 failed.*retrying/);
+    assert.match(output, /attempt 1\/5 failed.*retrying in/);
     assert.match(output, /credentials OK/);
   } finally {
     await new Promise<void>((resolve) => server.close(() => resolve()));


### PR DESCRIPTION
Tonight's scheduled run died 53 seconds in:

```
##[warning]preflight attempt 1/3 failed: fetch failed (ETIMEDOUT); retrying...
##[warning]preflight attempt 2/3 failed: fetch failed (ETIMEDOUT); retrying...
##[error]preflight: fetch failed (ETIMEDOUT)
```

Preflight is the gate the whole night runs behind, and its retry was `attempt * 1000` — **1s, then 2s**. A three-second window catches a single dropped packet and nothing else.

## This is the second night lost to it

| when | what | outcome |
| --- | --- | --- |
| 09-09 22:25 | nightly, preflight | rerun 4h later, unchanged, succeeded |
| 09-11 06:25 | nav regeneration | rerun succeeded |
| 09-11 06:58 | nav regeneration | rerun succeeded |
| 09-11 22:24 | nightly, preflight | rerunning now |

Five `ETIMEDOUT`s in three days, against **sixteen consecutive clean nights** before them (08-27 to 09-08, every one `attempt=1`). Every single failure recovered on a rerun with nothing changed. The endpoint blips; it does not break.

## The change

Five attempts over ~3.75 minutes — 15s, 30s, 60s, 120s.

The job has a 360-minute budget. When the endpoint is genuinely down this costs four minutes before failing; when it is merely blipping it recovers a night of translation that is currently being thrown away.

## What this does not touch

The translator package's own retry (`3s / 5s / 9s / 17s`, ~34s) stays as it is. Its two failures on 09-11 were during dense back-to-back navigation runs — eight rounds in an hour against an endpoint that had previously served one job a night. That load was mine, not the pipeline's, and the nightly's sixteen-day record says these settings are fine for what it actually carries. Widening a retry that is not failing under its real load would be trading something that works for a scenario I created.

If the nav generator needs it later, that is a separate change with its own evidence.

<details>
<summary>中文</summary>

今晚的定时运行在 53 秒时死掉,卡在 preflight 的 `ETIMEDOUT`。preflight 是整晚工作的前置闸门,而它的重试是 `attempt * 1000` —— **1 秒,然后 2 秒**。三秒的窗口只能挡住单个丢包,别的什么都挡不住。

**这已是第二个因此损失的夜晚**(见上表):三天内五次 `ETIMEDOUT`,而在此之前是**连续十六个干净的夜晚**(08-27 至 09-08,每次都是 `attempt=1`)。每一次失败都在原样重跑后成功。端点是抖动,不是坏掉。

**改动**:五次尝试,窗口约 3.75 分钟(15s、30s、60s、120s)。该 job 有 360 分钟预算 —— 端点真的宕机时,代价是四分钟后失败;而端点只是抖动时,挽回的是一整晚目前被白白丢弃的翻译。

**未触及的部分**:translator 包自身的重试(`3s / 5s / 9s / 17s`,约 34 秒)保持原样。它在 09-11 的两次失败发生在密集连跑导航生成期间 —— 一小时内八轮,而该端点此前每晚只服务一个任务。那个负载是我造成的,不是流水线的;夜间任务十六天的记录说明这套设置对它**实际承受**的负载是够的。为一个我自己制造的场景去放宽一个并未在真实负载下失败的重试,是拿有效的东西去换。若导航生成器日后确实需要,那是另一项改动,应有它自己的证据。

</details>

https://claude.ai/code/session_01Sa8YZQrbc74Rdsfbhibkjy