### PR TITLE
fix(translator): distinguish unwritten files from corrupt output

### DIFF
--- a/translator/orchestrator/orchestrator.mjs
+++ b/translator/orchestrator/orchestrator.mjs
@@ -1216,7 +1216,8 @@ function verifyFile(lang, f, manifest) {
       fs.utimesSync(target, targetStat.atime, targetStat.mtime);
     tg = healed;
   }
-  if (!touchedThisSession) problems.push("target not touched this session");
+  if (!touchedThisSession)
+    return { ok: false, problems: ["target not touched this session"] };
   problems.push(...structuralProblems(en, tg, lang));
   const linksEn = (en.match(/\]\(/g) || []).length;
   const linksTg = (tg.match(/\]\(/g) || []).length;
@@ -1639,7 +1640,19 @@ function cmdQuarantine() {
   let removed = 0;
   let advanced = 0;
   const unrepairable = [];
+  let unwritten = 0;
   for (const listName of lists) {
+    const metricsFile = path.join(
+      dir,
+      listName.replace(/\.failed\.txt$/, ".metrics.json")
+    );
+    const unwrittenFiles = new Set(
+      fs.existsSync(metricsFile)
+        ? JSON.parse(fs.readFileSync(metricsFile, "utf8")).failures
+            .filter((f) => f.problems.includes("target not touched this session"))
+            .map((f) => f.file)
+        : []
+    );
     const entries = fs
       .readFileSync(path.join(dir, listName), "utf8")
       .split("\n")
@@ -1650,6 +1663,13 @@ function cmdQuarantine() {
       if (slash < 0) continue;
       const lang = entry.slice(0, slash);
       const rel = entry.slice(slash + 1);
+      if (unwrittenFiles.has(rel)) {
+        unwritten++;
+        console.log(
+          `::warning::${entry}: target not touched this session; retaining the existing translation for retry`
+        );
+        continue;
+      }
       const target = path.join(OPTS.contentDir, lang, rel);
       const repoRel = path.relative(ROOT, target).split(path.sep).join("/");
       const head = readFromHead(repoRel);
@@ -1703,7 +1723,7 @@ function cmdQuarantine() {
   console.log(
     `[orch] quarantine: ${restored} restored from HEAD, ${kept} kept over a corrupt HEAD, ` +
       `${advanced} kept as closer to the source, ` +
-      `${removed} removed, ${unrepairable.length} unrepairable`
+      `${removed} removed, ${unrepairable.length} unrepairable, ${unwritten} not written`
   );
   if (unrepairable.length) {
     const report = path.join(dir, "quarantine-unrepairable.json");

--- a/translator/src/orchestrator.test.ts
+++ b/translator/src/orchestrator.test.ts
@@ -101,16 +101,16 @@ test("self-heals closed target-only frontmatter without refreshing a stale file"
   }
 });
 
-test("quarantine keeps a sound replacement over corrupt HEAD", () => {
+test("quarantine separates unwritten files from rejected translations", () => {
   const root = fs.realpathSync(
-    fs.mkdtempSync(path.join(os.tmpdir(), "qwen-quarantine-test-"))
+    fs.mkdtempSync(path.join(os.tmpdir(), "qwen-quarantine-test-")),
   );
   const contentDir = path.join(root, "website", "content");
   const copiedOrchestrator = path.join(
     root,
     "translator",
     "orchestrator",
-    "orchestrator.mjs"
+    "orchestrator.mjs",
   );
 
   try {
@@ -118,10 +118,25 @@ test("quarantine keeps a sound replacement over corrupt HEAD", () => {
     fs.mkdirSync(path.join(contentDir, "en"), { recursive: true });
     fs.mkdirSync(path.join(contentDir, "zh"), { recursive: true });
     fs.copyFileSync(orchestrator, copiedOrchestrator);
-    fs.writeFileSync(path.join(contentDir, "en", "repaired.md"), "# Repaired\n");
-    fs.writeFileSync(path.join(contentDir, "zh", "repaired.md"), "---\n\n# 损坏\n");
-    fs.writeFileSync(path.join(contentDir, "en", "restored.md"), "# Restored\n");
+    fs.writeFileSync(
+      path.join(contentDir, "en", "repaired.md"),
+      "# Repaired\n",
+    );
+    fs.writeFileSync(
+      path.join(contentDir, "zh", "repaired.md"),
+      "---\n\n# 损坏\n",
+    );
+    fs.writeFileSync(
+      path.join(contentDir, "en", "restored.md"),
+      "# Restored\n",
+    );
     fs.writeFileSync(path.join(contentDir, "zh", "restored.md"), "# 原版本\n");
+    fs.writeFileSync(
+      path.join(contentDir, "en", "unwritten.md"),
+      "# Updated\n```sh\nqwen\n```\n",
+    );
+    const unwritten = path.join(contentDir, "zh", "unwritten.md");
+    fs.writeFileSync(unwritten, "# 旧译文\n");
 
     execFileSync("git", ["init", "-q"], { cwd: root });
     execFileSync("git", ["config", "user.email", "test@example.com"], {
@@ -131,11 +146,57 @@ test("quarantine keeps a sound replacement over corrupt HEAD", () => {
     execFileSync("git", ["add", "."], { cwd: root });
     execFileSync("git", ["commit", "-qm", "fixture"], { cwd: root });
 
+    const stale = new Date("2000-01-01T00:00:00Z");
+    fs.utimesSync(unwritten, stale, stale);
+    const manifest = path.join(
+      root,
+      "website",
+      "orchestrator-manifest-zh.json",
+    );
+    fs.writeFileSync(
+      manifest,
+      JSON.stringify({
+        createdAt: Date.now(),
+        files: ["docs/unwritten.md"],
+      }),
+    );
+    const verify = spawnSync(
+      process.execPath,
+      [
+        copiedOrchestrator,
+        "verify",
+        "--lang",
+        "zh",
+        "--content-dir",
+        contentDir,
+        "--manifest",
+        manifest,
+      ],
+      { encoding: "utf8" },
+    );
+    assert.equal(verify.status, 1, verify.stdout || verify.stderr);
+    assert.match(verify.stdout, /target not touched this session/);
+    assert.doesNotMatch(verify.stdout, /code fence mismatch/);
+    fs.writeFileSync(
+      path.join(root, "website", "orchestrator-manifest-zh.metrics.json"),
+      JSON.stringify({
+        failures: [
+          {
+            file: "unwritten.md",
+            problems: ["target not touched this session"],
+          },
+        ],
+      }),
+    );
+
     fs.writeFileSync(path.join(contentDir, "zh", "repaired.md"), "# 已修复\n");
-    fs.writeFileSync(path.join(contentDir, "zh", "restored.md"), "```\n# 损坏\n");
+    fs.writeFileSync(
+      path.join(contentDir, "zh", "restored.md"),
+      "```\n# 损坏\n",
+    );
     fs.writeFileSync(
       path.join(root, "website", "orchestrator-manifest-zh.failed.txt"),
-      "zh/repaired.md\nzh/restored.md\n"
+      "zh/repaired.md\nzh/restored.md\nzh/unwritten.md\n",
     );
 
     const result = spawnSync(
@@ -148,23 +209,30 @@ test("quarantine keeps a sound replacement over corrupt HEAD", () => {
         "--baseline",
         path.join(root, "website", "last-sync.json"),
       ],
-      { encoding: "utf8" }
+      { encoding: "utf8" },
     );
 
     assert.equal(result.status, 0, result.stdout || result.stderr);
     assert.ok(
       fs.existsSync(path.join(contentDir, "zh", "repaired.md")),
-      result.stdout || result.stderr
+      result.stdout || result.stderr,
     );
     assert.equal(
       fs.readFileSync(path.join(contentDir, "zh", "repaired.md"), "utf8"),
-      "# 已修复\n"
+      "# 已修复\n",
     );
     assert.equal(
       fs.readFileSync(path.join(contentDir, "zh", "restored.md"), "utf8"),
-      "# 原版本\n"
+      "# 原版本\n",
     );
-    assert.match(result.stdout, /1 restored from HEAD, 1 kept over a corrupt HEAD/);
+    assert.match(
+      result.stdout,
+      /1 restored from HEAD, 1 kept over a corrupt HEAD/,
+    );
+    assert.match(result.stdout, /0 unrepairable, 1 not written/);
+    assert.doesNotMatch(result.stdout, /unwritten\.md: HEAD.*corrupt/);
+    assert.equal(fs.readFileSync(unwritten, "utf8"), "# 旧译文\n");
+    assert.equal(fs.statSync(unwritten).mtimeMs, stale.getTime());
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

An existing translation that was never updated in the current run can differ from the newer English source. Verification currently reports both “target not touched this session” and structural mismatches, and quarantine can then mislabel the unchanged translation as corrupt. This obscures the missing-output failure described in #260.

Report untouched targets as missing output, without attributing stale-source differences to newly generated content. Quarantine uses the corresponding verification metrics to retain those translations for retry without labeling them corrupt. They still fail verification and do not advance the translation baseline. Actual rejected translations continue through the existing quarantine checks.

Addresses part of #260; this does not claim to fix every cause of missing model output.

## Verification

- All 9 tests in the orchestrator and orchestrator-security test files passed.
- JavaScript syntax and whitespace checks passed.
- Regression coverage verifies that an untouched translation behind an updated English code fence is reported as unwritten, remains unchanged with its original modification time, and does not enter the corrupt-output quarantine path. Existing restore and keep behavior is covered in the same fixture.

## Reviewer test plan

Check that a stale, untouched translation remains failed and eligible for retry without being counted as structural corruption. Newly written malformed output should still be restored or quarantined as before.
